### PR TITLE
Camel case need only first uppercase character and at least 1 lowerca…

### DIFF
--- a/linter/formatChecks.go
+++ b/linter/formatChecks.go
@@ -8,9 +8,8 @@ import (
 
 func isCamelCase(s string) bool {
 	first, _ := utf8.DecodeRuneInString(s)
-	last, _ := utf8.DecodeLastRuneInString(s)
 	if unicode.IsLower(first) ||
-		unicode.IsUpper(last) ||
+		s == strings.ToUpper(s) ||
 		strings.Contains(s, "_") {
 		return false
 	}


### PR DESCRIPTION
Check for camel case in this plugin should be contains the first uppercase character and at least one lower case character and do not contains underscore character.