### PR TITLE
Add sort_imports parameter for import statement order check

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,11 +3,16 @@ package main
 import (
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/ckaznocha/protoc-gen-lint/linter"
 	"github.com/golang/protobuf/proto"
 	protoc "github.com/golang/protobuf/protoc-gen-go/plugin"
 )
+
+// SortImports represents the parameter, which can be specified to the tool invocation
+// to enable checking, whether the proto file imports are sorted alphabetically.
+const SortImports = "sort_imports"
 
 func panicOnError(err error) {
 	if err != nil {
@@ -16,11 +21,20 @@ func panicOnError(err error) {
 }
 
 func main() {
-
 	var (
 		totalErrors      int
 		generatorRequest protoc.CodeGeneratorRequest
+		parameters       struct {
+			SortImports bool
+		}
 	)
+
+	for _, p := range strings.Split(generatorRequest.GetParameter(), ",") {
+		switch p {
+		case SortImports:
+			parameters.SortImports = true
+		}
+	}
 
 	data, err := ioutil.ReadAll(os.Stdin)
 	panicOnError(err)
@@ -28,7 +42,11 @@ func main() {
 	panicOnError(proto.Unmarshal(data, &generatorRequest))
 
 	for _, file := range generatorRequest.GetProtoFile() {
-		numErrors, err := linter.LintProtoFile(file, os.Stderr)
+		numErrors, err := linter.LintProtoFile(linter.Config{
+			ProtoFile:   file,
+			OutFile:     os.Stderr,
+			SortImports: parameters.SortImports,
+		})
 		panicOnError(err)
 		totalErrors += numErrors
 	}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -33,7 +34,13 @@ func main() {
 		switch p {
 		case SortImports:
 			parameters.SortImports = true
+		default:
+			fmt.Fprintf(os.Stderr, "Unmatched parameter: %s", p)
+			totalErrors++
 		}
+	}
+	if totalErrors != 0 {
+		os.Exit(1)
 	}
 
 	data, err := ioutil.ReadAll(os.Stdin)


### PR DESCRIPTION
Made the import statement order check optional to avoid issues like mentioned here: https://github.com/ckaznocha/protoc-gen-lint/issues/10#issuecomment-361405954
Closes #10 