### PR TITLE
Fix isCamelCase to allow numeric character

### DIFF
--- a/linter/formatChecks.go
+++ b/linter/formatChecks.go
@@ -1,19 +1,15 @@
 package linter
 
 import (
+	"regexp"
 	"strings"
-	"unicode"
-	"unicode/utf8"
 )
 
+// @see https://google.github.io/styleguide/javaguide.html#s5.3-camel-case
+var camelCaseRegexPattern, _ = regexp.Compile("\\A([A-Z][a-z0-9]+)((\\d)|([A-Z0-9][a-z0-9]+))*\\z")
+
 func isCamelCase(s string) bool {
-	first, _ := utf8.DecodeRuneInString(s)
-	if unicode.IsLower(first) ||
-		s == strings.ToUpper(s) ||
-		strings.Contains(s, "_") {
-		return false
-	}
-	return true
+	return camelCaseRegexPattern.Match([]byte(s))
 }
 
 func isLowerUnderscore(s string) bool {

--- a/linter/formatChecks_test.go
+++ b/linter/formatChecks_test.go
@@ -13,8 +13,8 @@ func TestIsCamelCase(t *testing.T) {
 		{"helloworld", false},
 		{"HELLOWORLD", false},
 		{"HelloWorld", true},
-		{"Sha512", true},
-		{"sha512", false},
+		{"h264", false},
+		{"H264", true},
 	}
 
 	for _, v := range stringsToTest {

--- a/linter/formatChecks_test.go
+++ b/linter/formatChecks_test.go
@@ -13,6 +13,8 @@ func TestIsCamelCase(t *testing.T) {
 		{"helloworld", false},
 		{"HELLOWORLD", false},
 		{"HelloWorld", true},
+		{"Sha512", true},
+		{"sha512", false},
 	}
 
 	for _, v := range stringsToTest {


### PR DESCRIPTION
Fix to use the name which consisted with one alphabetic character and non-alphabetic characters in message. like "H264", "C99", "S3", etc.

Google allows camelcase contains number in [Java Style Guide](https://google.github.io/styleguide/javaguide.html#s5.3-camel-case).

The regexp pattern is copied from [Stack Overflow](https://stackoverflow.com/a/47591707) with some change.
