### PR TITLE
Support 'optional' fields in proto3

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,5 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
-google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/main.go
+++ b/main.go
@@ -1,63 +1,65 @@
 package main
 
 import (
+	"errors"
+	"flag"
 	"fmt"
-	"io"
 	"os"
-	"strings"
 
-	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/types/pluginpb"
 
 	"github.com/ckaznocha/protoc-gen-lint/linter"
 )
 
-// SortImports represents the parameter, which can be specified to the tool invocation
-// to enable checking, whether the proto file imports are sorted alphabetically.
-const SortImports = "sort_imports"
+type BoolFlag interface {
+	IsBoolFlag() bool
+}
+
+var errLint = errors.New("encountered lint errors")
 
 func main() {
-	var (
-		totalErrors      int
-		generatorRequest pluginpb.CodeGeneratorRequest
-		parameters       struct {
-			SortImports bool
-		}
-	)
 
-	data, err := io.ReadAll(os.Stdin)
-	if err != nil {
-		panic(err)
-	}
+	var flags flag.FlagSet
+	sortImports := flags.Bool("sort_imports", false, "check whether or not the proto "+
+		"file imports are sorted alphabetically")
 
-	if err := proto.Unmarshal(data, &generatorRequest); err != nil {
-		panic(err)
-	}
+	protogen.Options{
+		ParamFunc: func(param, value string) error {
+			// For backwards compatibility, treat a present flag with an empty
+			// string value as boolean true. The Go flag module parsing
+			// handles this, but the protogen flag parse behavior doesn't,
+			// because it doesn't parse flags the same way.
+			f := flags.Lookup(param)
+			if f != nil {
+				if _, ok := f.Value.(BoolFlag); ok {
+					value = "true"
+				}
+			}
 
-	for _, p := range strings.Split(generatorRequest.GetParameter(), ",") {
-		switch strings.TrimSpace(p) {
-		case "":
-			continue
-		case SortImports:
-			parameters.SortImports = true
-		default:
-			fmt.Fprintf(os.Stderr, "Unmatched parameter: %s", p)
-			os.Exit(1)
-		}
-	}
+			return flags.Set(param, value)
+		},
+	}.Run(func(gen *protogen.Plugin) error {
+		gen.SupportedFeatures = uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
 
-	for _, file := range generatorRequest.GetProtoFile() {
-		numErrors, err := linter.LintProtoFile(linter.Config{
-			ProtoFile:   file,
-			OutFile:     os.Stderr,
-			SortImports: parameters.SortImports,
-		})
-		if err != nil {
-			panic(err)
+		totalErrors := 0
+		for _, f := range gen.Files {
+			numErrors, err := linter.LintProtoFile(linter.Config{
+				ProtoFile:   f.Proto,
+				OutFile:     os.Stderr,
+				SortImports: *sortImports,
+			})
+			if err != nil {
+				return err
+			}
+
+			totalErrors += numErrors
 		}
 
-		totalErrors += numErrors
-	}
+		if totalErrors > 0 {
+			return fmt.Errorf("%w: %d total", errLint, totalErrors)
+		}
 
-	os.Exit(totalErrors)
+		return nil
+	})
 }

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ type BoolFlag interface {
 var errLint = errors.New("encountered lint errors")
 
 func main() {
-
 	var flags flag.FlagSet
 	sortImports := flags.Bool("sort_imports", false, "check whether or not the proto "+
 		"file imports are sorted alphabetically")

--- a/optional.proto
+++ b/optional.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package test.optional;
+
+message WithOptional {
+	optional string test = 1;
+}

--- a/vendor/google.golang.org/protobuf/compiler/protogen/protogen.go
+++ b/vendor/google.golang.org/protobuf/compiler/protogen/protogen.go
@@ -1,0 +1,1261 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package protogen provides support for writing protoc plugins.
+//
+// Plugins for protoc, the Protocol Buffer compiler,
+// are programs which read a CodeGeneratorRequest message from standard input
+// and write a CodeGeneratorResponse message to standard output.
+// This package provides support for writing plugins which generate Go code.
+package protogen
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"go/types"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/internal/genid"
+	"google.golang.org/protobuf/internal/strs"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/pluginpb"
+)
+
+const goPackageDocURL = "https://developers.google.com/protocol-buffers/docs/reference/go-generated#package"
+
+// Run executes a function as a protoc plugin.
+//
+// It reads a CodeGeneratorRequest message from os.Stdin, invokes the plugin
+// function, and writes a CodeGeneratorResponse message to os.Stdout.
+//
+// If a failure occurs while reading or writing, Run prints an error to
+// os.Stderr and calls os.Exit(1).
+func (opts Options) Run(f func(*Plugin) error) {
+	if err := run(opts, f); err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", filepath.Base(os.Args[0]), err)
+		os.Exit(1)
+	}
+}
+
+func run(opts Options, f func(*Plugin) error) error {
+	if len(os.Args) > 1 {
+		return fmt.Errorf("unknown argument %q (this program should be run by protoc, not directly)", os.Args[1])
+	}
+	in, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		return err
+	}
+	req := &pluginpb.CodeGeneratorRequest{}
+	if err := proto.Unmarshal(in, req); err != nil {
+		return err
+	}
+	gen, err := opts.New(req)
+	if err != nil {
+		return err
+	}
+	if err := f(gen); err != nil {
+		// Errors from the plugin function are reported by setting the
+		// error field in the CodeGeneratorResponse.
+		//
+		// In contrast, errors that indicate a problem in protoc
+		// itself (unparsable input, I/O errors, etc.) are reported
+		// to stderr.
+		gen.Error(err)
+	}
+	resp := gen.Response()
+	out, err := proto.Marshal(resp)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stdout.Write(out); err != nil {
+		return err
+	}
+	return nil
+}
+
+// A Plugin is a protoc plugin invocation.
+type Plugin struct {
+	// Request is the CodeGeneratorRequest provided by protoc.
+	Request *pluginpb.CodeGeneratorRequest
+
+	// Files is the set of files to generate and everything they import.
+	// Files appear in topological order, so each file appears before any
+	// file that imports it.
+	Files       []*File
+	FilesByPath map[string]*File
+
+	// SupportedFeatures is the set of protobuf language features supported by
+	// this generator plugin. See the documentation for
+	// google.protobuf.CodeGeneratorResponse.supported_features for details.
+	SupportedFeatures uint64
+
+	fileReg        *protoregistry.Files
+	enumsByName    map[protoreflect.FullName]*Enum
+	messagesByName map[protoreflect.FullName]*Message
+	annotateCode   bool
+	pathType       pathType
+	module         string
+	genFiles       []*GeneratedFile
+	opts           Options
+	err            error
+}
+
+type Options struct {
+	// If ParamFunc is non-nil, it will be called with each unknown
+	// generator parameter.
+	//
+	// Plugins for protoc can accept parameters from the command line,
+	// passed in the --<lang>_out protoc, separated from the output
+	// directory with a colon; e.g.,
+	//
+	//   --go_out=<param1>=<value1>,<param2>=<value2>:<output_directory>
+	//
+	// Parameters passed in this fashion as a comma-separated list of
+	// key=value pairs will be passed to the ParamFunc.
+	//
+	// The (flag.FlagSet).Set method matches this function signature,
+	// so parameters can be converted into flags as in the following:
+	//
+	//   var flags flag.FlagSet
+	//   value := flags.Bool("param", false, "")
+	//   opts := &protogen.Options{
+	//     ParamFunc: flags.Set,
+	//   }
+	//   protogen.Run(opts, func(p *protogen.Plugin) error {
+	//     if *value { ... }
+	//   })
+	ParamFunc func(name, value string) error
+
+	// ImportRewriteFunc is called with the import path of each package
+	// imported by a generated file. It returns the import path to use
+	// for this package.
+	ImportRewriteFunc func(GoImportPath) GoImportPath
+}
+
+// New returns a new Plugin.
+func (opts Options) New(req *pluginpb.CodeGeneratorRequest) (*Plugin, error) {
+	gen := &Plugin{
+		Request:        req,
+		FilesByPath:    make(map[string]*File),
+		fileReg:        new(protoregistry.Files),
+		enumsByName:    make(map[protoreflect.FullName]*Enum),
+		messagesByName: make(map[protoreflect.FullName]*Message),
+		opts:           opts,
+	}
+
+	packageNames := make(map[string]GoPackageName) // filename -> package name
+	importPaths := make(map[string]GoImportPath)   // filename -> import path
+	for _, param := range strings.Split(req.GetParameter(), ",") {
+		var value string
+		if i := strings.Index(param, "="); i >= 0 {
+			value = param[i+1:]
+			param = param[0:i]
+		}
+		switch param {
+		case "":
+			// Ignore.
+		case "module":
+			gen.module = value
+		case "paths":
+			switch value {
+			case "import":
+				gen.pathType = pathTypeImport
+			case "source_relative":
+				gen.pathType = pathTypeSourceRelative
+			default:
+				return nil, fmt.Errorf(`unknown path type %q: want "import" or "source_relative"`, value)
+			}
+		case "annotate_code":
+			switch value {
+			case "true", "":
+				gen.annotateCode = true
+			case "false":
+			default:
+				return nil, fmt.Errorf(`bad value for parameter %q: want "true" or "false"`, param)
+			}
+		default:
+			if param[0] == 'M' {
+				impPath, pkgName := splitImportPathAndPackageName(value)
+				if pkgName != "" {
+					packageNames[param[1:]] = pkgName
+				}
+				if impPath != "" {
+					importPaths[param[1:]] = impPath
+				}
+				continue
+			}
+			if opts.ParamFunc != nil {
+				if err := opts.ParamFunc(param, value); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	// When the module= option is provided, we strip the module name
+	// prefix from generated files. This only makes sense if generated
+	// filenames are based on the import path.
+	if gen.module != "" && gen.pathType == pathTypeSourceRelative {
+		return nil, fmt.Errorf("cannot use module= with paths=source_relative")
+	}
+
+	// Figure out the import path and package name for each file.
+	//
+	// The rules here are complicated and have grown organically over time.
+	// Interactions between different ways of specifying package information
+	// may be surprising.
+	//
+	// The recommended approach is to include a go_package option in every
+	// .proto source file specifying the full import path of the Go package
+	// associated with this file.
+	//
+	//     option go_package = "google.golang.org/protobuf/types/known/anypb";
+	//
+	// Alternatively, build systems which want to exert full control over
+	// import paths may specify M<filename>=<import_path> flags.
+	for _, fdesc := range gen.Request.ProtoFile {
+		// The "M" command-line flags take precedence over
+		// the "go_package" option in the .proto source file.
+		filename := fdesc.GetName()
+		impPath, pkgName := splitImportPathAndPackageName(fdesc.GetOptions().GetGoPackage())
+		if importPaths[filename] == "" && impPath != "" {
+			importPaths[filename] = impPath
+		}
+		if packageNames[filename] == "" && pkgName != "" {
+			packageNames[filename] = pkgName
+		}
+		switch {
+		case importPaths[filename] == "":
+			// The import path must be specified one way or another.
+			return nil, fmt.Errorf(
+				"unable to determine Go import path for %q\n\n"+
+					"Please specify either:\n"+
+					"\t• a \"go_package\" option in the .proto source file, or\n"+
+					"\t• a \"M\" argument on the command line.\n\n"+
+					"See %v for more information.\n",
+				fdesc.GetName(), goPackageDocURL)
+		case !strings.Contains(string(importPaths[filename]), ".") &&
+			!strings.Contains(string(importPaths[filename]), "/"):
+			// Check that import paths contain at least a dot or slash to avoid
+			// a common mistake where import path is confused with package name.
+			return nil, fmt.Errorf(
+				"invalid Go import path %q for %q\n\n"+
+					"The import path must contain at least one period ('.') or forward slash ('/') character.\n\n"+
+					"See %v for more information.\n",
+				string(importPaths[filename]), fdesc.GetName(), goPackageDocURL)
+		case packageNames[filename] == "":
+			// If the package name is not explicitly specified,
+			// then derive a reasonable package name from the import path.
+			//
+			// NOTE: The package name is derived first from the import path in
+			// the "go_package" option (if present) before trying the "M" flag.
+			// The inverted order for this is because the primary use of the "M"
+			// flag is by build systems that have full control over the
+			// import paths all packages, where it is generally expected that
+			// the Go package name still be identical for the Go toolchain and
+			// for custom build systems like Bazel.
+			if impPath == "" {
+				impPath = importPaths[filename]
+			}
+			packageNames[filename] = cleanPackageName(path.Base(string(impPath)))
+		}
+	}
+
+	// Consistency check: Every file with the same Go import path should have
+	// the same Go package name.
+	packageFiles := make(map[GoImportPath][]string)
+	for filename, importPath := range importPaths {
+		if _, ok := packageNames[filename]; !ok {
+			// Skip files mentioned in a M<file>=<import_path> parameter
+			// but which do not appear in the CodeGeneratorRequest.
+			continue
+		}
+		packageFiles[importPath] = append(packageFiles[importPath], filename)
+	}
+	for importPath, filenames := range packageFiles {
+		for i := 1; i < len(filenames); i++ {
+			if a, b := packageNames[filenames[0]], packageNames[filenames[i]]; a != b {
+				return nil, fmt.Errorf("Go package %v has inconsistent names %v (%v) and %v (%v)",
+					importPath, a, filenames[0], b, filenames[i])
+			}
+		}
+	}
+
+	for _, fdesc := range gen.Request.ProtoFile {
+		filename := fdesc.GetName()
+		if gen.FilesByPath[filename] != nil {
+			return nil, fmt.Errorf("duplicate file name: %q", filename)
+		}
+		f, err := newFile(gen, fdesc, packageNames[filename], importPaths[filename])
+		if err != nil {
+			return nil, err
+		}
+		gen.Files = append(gen.Files, f)
+		gen.FilesByPath[filename] = f
+	}
+	for _, filename := range gen.Request.FileToGenerate {
+		f, ok := gen.FilesByPath[filename]
+		if !ok {
+			return nil, fmt.Errorf("no descriptor for generated file: %v", filename)
+		}
+		f.Generate = true
+	}
+	return gen, nil
+}
+
+// Error records an error in code generation. The generator will report the
+// error back to protoc and will not produce output.
+func (gen *Plugin) Error(err error) {
+	if gen.err == nil {
+		gen.err = err
+	}
+}
+
+// Response returns the generator output.
+func (gen *Plugin) Response() *pluginpb.CodeGeneratorResponse {
+	resp := &pluginpb.CodeGeneratorResponse{}
+	if gen.err != nil {
+		resp.Error = proto.String(gen.err.Error())
+		return resp
+	}
+	for _, g := range gen.genFiles {
+		if g.skip {
+			continue
+		}
+		content, err := g.Content()
+		if err != nil {
+			return &pluginpb.CodeGeneratorResponse{
+				Error: proto.String(err.Error()),
+			}
+		}
+		filename := g.filename
+		if gen.module != "" {
+			trim := gen.module + "/"
+			if !strings.HasPrefix(filename, trim) {
+				return &pluginpb.CodeGeneratorResponse{
+					Error: proto.String(fmt.Sprintf("%v: generated file does not match prefix %q", filename, gen.module)),
+				}
+			}
+			filename = strings.TrimPrefix(filename, trim)
+		}
+		resp.File = append(resp.File, &pluginpb.CodeGeneratorResponse_File{
+			Name:    proto.String(filename),
+			Content: proto.String(string(content)),
+		})
+		if gen.annotateCode && strings.HasSuffix(g.filename, ".go") {
+			meta, err := g.metaFile(content)
+			if err != nil {
+				return &pluginpb.CodeGeneratorResponse{
+					Error: proto.String(err.Error()),
+				}
+			}
+			resp.File = append(resp.File, &pluginpb.CodeGeneratorResponse_File{
+				Name:    proto.String(filename + ".meta"),
+				Content: proto.String(meta),
+			})
+		}
+	}
+	if gen.SupportedFeatures > 0 {
+		resp.SupportedFeatures = proto.Uint64(gen.SupportedFeatures)
+	}
+	return resp
+}
+
+// A File describes a .proto source file.
+type File struct {
+	Desc  protoreflect.FileDescriptor
+	Proto *descriptorpb.FileDescriptorProto
+
+	GoDescriptorIdent GoIdent       // name of Go variable for the file descriptor
+	GoPackageName     GoPackageName // name of this file's Go package
+	GoImportPath      GoImportPath  // import path of this file's Go package
+
+	Enums      []*Enum      // top-level enum declarations
+	Messages   []*Message   // top-level message declarations
+	Extensions []*Extension // top-level extension declarations
+	Services   []*Service   // top-level service declarations
+
+	Generate bool // true if we should generate code for this file
+
+	// GeneratedFilenamePrefix is used to construct filenames for generated
+	// files associated with this source file.
+	//
+	// For example, the source file "dir/foo.proto" might have a filename prefix
+	// of "dir/foo". Appending ".pb.go" produces an output file of "dir/foo.pb.go".
+	GeneratedFilenamePrefix string
+
+	location Location
+}
+
+func newFile(gen *Plugin, p *descriptorpb.FileDescriptorProto, packageName GoPackageName, importPath GoImportPath) (*File, error) {
+	desc, err := protodesc.NewFile(p, gen.fileReg)
+	if err != nil {
+		return nil, fmt.Errorf("invalid FileDescriptorProto %q: %v", p.GetName(), err)
+	}
+	if err := gen.fileReg.RegisterFile(desc); err != nil {
+		return nil, fmt.Errorf("cannot register descriptor %q: %v", p.GetName(), err)
+	}
+	f := &File{
+		Desc:          desc,
+		Proto:         p,
+		GoPackageName: packageName,
+		GoImportPath:  importPath,
+		location:      Location{SourceFile: desc.Path()},
+	}
+
+	// Determine the prefix for generated Go files.
+	prefix := p.GetName()
+	if ext := path.Ext(prefix); ext == ".proto" || ext == ".protodevel" {
+		prefix = prefix[:len(prefix)-len(ext)]
+	}
+	switch gen.pathType {
+	case pathTypeImport:
+		// If paths=import, the output filename is derived from the Go import path.
+		prefix = path.Join(string(f.GoImportPath), path.Base(prefix))
+	case pathTypeSourceRelative:
+		// If paths=source_relative, the output filename is derived from
+		// the input filename.
+	}
+	f.GoDescriptorIdent = GoIdent{
+		GoName:       "File_" + strs.GoSanitized(p.GetName()),
+		GoImportPath: f.GoImportPath,
+	}
+	f.GeneratedFilenamePrefix = prefix
+
+	for i, eds := 0, desc.Enums(); i < eds.Len(); i++ {
+		f.Enums = append(f.Enums, newEnum(gen, f, nil, eds.Get(i)))
+	}
+	for i, mds := 0, desc.Messages(); i < mds.Len(); i++ {
+		f.Messages = append(f.Messages, newMessage(gen, f, nil, mds.Get(i)))
+	}
+	for i, xds := 0, desc.Extensions(); i < xds.Len(); i++ {
+		f.Extensions = append(f.Extensions, newField(gen, f, nil, xds.Get(i)))
+	}
+	for i, sds := 0, desc.Services(); i < sds.Len(); i++ {
+		f.Services = append(f.Services, newService(gen, f, sds.Get(i)))
+	}
+	for _, message := range f.Messages {
+		if err := message.resolveDependencies(gen); err != nil {
+			return nil, err
+		}
+	}
+	for _, extension := range f.Extensions {
+		if err := extension.resolveDependencies(gen); err != nil {
+			return nil, err
+		}
+	}
+	for _, service := range f.Services {
+		for _, method := range service.Methods {
+			if err := method.resolveDependencies(gen); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return f, nil
+}
+
+// splitImportPathAndPackageName splits off the optional Go package name
+// from the Go import path when separated by a ';' delimiter.
+func splitImportPathAndPackageName(s string) (GoImportPath, GoPackageName) {
+	if i := strings.Index(s, ";"); i >= 0 {
+		return GoImportPath(s[:i]), GoPackageName(s[i+1:])
+	}
+	return GoImportPath(s), ""
+}
+
+// An Enum describes an enum.
+type Enum struct {
+	Desc protoreflect.EnumDescriptor
+
+	GoIdent GoIdent // name of the generated Go type
+
+	Values []*EnumValue // enum value declarations
+
+	Location Location   // location of this enum
+	Comments CommentSet // comments associated with this enum
+}
+
+func newEnum(gen *Plugin, f *File, parent *Message, desc protoreflect.EnumDescriptor) *Enum {
+	var loc Location
+	if parent != nil {
+		loc = parent.Location.appendPath(genid.DescriptorProto_EnumType_field_number, desc.Index())
+	} else {
+		loc = f.location.appendPath(genid.FileDescriptorProto_EnumType_field_number, desc.Index())
+	}
+	enum := &Enum{
+		Desc:     desc,
+		GoIdent:  newGoIdent(f, desc),
+		Location: loc,
+		Comments: makeCommentSet(f.Desc.SourceLocations().ByDescriptor(desc)),
+	}
+	gen.enumsByName[desc.FullName()] = enum
+	for i, vds := 0, enum.Desc.Values(); i < vds.Len(); i++ {
+		enum.Values = append(enum.Values, newEnumValue(gen, f, parent, enum, vds.Get(i)))
+	}
+	return enum
+}
+
+// An EnumValue describes an enum value.
+type EnumValue struct {
+	Desc protoreflect.EnumValueDescriptor
+
+	GoIdent GoIdent // name of the generated Go declaration
+
+	Parent *Enum // enum in which this value is declared
+
+	Location Location   // location of this enum value
+	Comments CommentSet // comments associated with this enum value
+}
+
+func newEnumValue(gen *Plugin, f *File, message *Message, enum *Enum, desc protoreflect.EnumValueDescriptor) *EnumValue {
+	// A top-level enum value's name is: EnumName_ValueName
+	// An enum value contained in a message is: MessageName_ValueName
+	//
+	// For historical reasons, enum value names are not camel-cased.
+	parentIdent := enum.GoIdent
+	if message != nil {
+		parentIdent = message.GoIdent
+	}
+	name := parentIdent.GoName + "_" + string(desc.Name())
+	loc := enum.Location.appendPath(genid.EnumDescriptorProto_Value_field_number, desc.Index())
+	return &EnumValue{
+		Desc:     desc,
+		GoIdent:  f.GoImportPath.Ident(name),
+		Parent:   enum,
+		Location: loc,
+		Comments: makeCommentSet(f.Desc.SourceLocations().ByDescriptor(desc)),
+	}
+}
+
+// A Message describes a message.
+type Message struct {
+	Desc protoreflect.MessageDescriptor
+
+	GoIdent GoIdent // name of the generated Go type
+
+	Fields []*Field // message field declarations
+	Oneofs []*Oneof // message oneof declarations
+
+	Enums      []*Enum      // nested enum declarations
+	Messages   []*Message   // nested message declarations
+	Extensions []*Extension // nested extension declarations
+
+	Location Location   // location of this message
+	Comments CommentSet // comments associated with this message
+}
+
+func newMessage(gen *Plugin, f *File, parent *Message, desc protoreflect.MessageDescriptor) *Message {
+	var loc Location
+	if parent != nil {
+		loc = parent.Location.appendPath(genid.DescriptorProto_NestedType_field_number, desc.Index())
+	} else {
+		loc = f.location.appendPath(genid.FileDescriptorProto_MessageType_field_number, desc.Index())
+	}
+	message := &Message{
+		Desc:     desc,
+		GoIdent:  newGoIdent(f, desc),
+		Location: loc,
+		Comments: makeCommentSet(f.Desc.SourceLocations().ByDescriptor(desc)),
+	}
+	gen.messagesByName[desc.FullName()] = message
+	for i, eds := 0, desc.Enums(); i < eds.Len(); i++ {
+		message.Enums = append(message.Enums, newEnum(gen, f, message, eds.Get(i)))
+	}
+	for i, mds := 0, desc.Messages(); i < mds.Len(); i++ {
+		message.Messages = append(message.Messages, newMessage(gen, f, message, mds.Get(i)))
+	}
+	for i, fds := 0, desc.Fields(); i < fds.Len(); i++ {
+		message.Fields = append(message.Fields, newField(gen, f, message, fds.Get(i)))
+	}
+	for i, ods := 0, desc.Oneofs(); i < ods.Len(); i++ {
+		message.Oneofs = append(message.Oneofs, newOneof(gen, f, message, ods.Get(i)))
+	}
+	for i, xds := 0, desc.Extensions(); i < xds.Len(); i++ {
+		message.Extensions = append(message.Extensions, newField(gen, f, message, xds.Get(i)))
+	}
+
+	// Resolve local references between fields and oneofs.
+	for _, field := range message.Fields {
+		if od := field.Desc.ContainingOneof(); od != nil {
+			oneof := message.Oneofs[od.Index()]
+			field.Oneof = oneof
+			oneof.Fields = append(oneof.Fields, field)
+		}
+	}
+
+	// Field name conflict resolution.
+	//
+	// We assume well-known method names that may be attached to a generated
+	// message type, as well as a 'Get*' method for each field. For each
+	// field in turn, we add _s to its name until there are no conflicts.
+	//
+	// Any change to the following set of method names is a potential
+	// incompatible API change because it may change generated field names.
+	//
+	// TODO: If we ever support a 'go_name' option to set the Go name of a
+	// field, we should consider dropping this entirely. The conflict
+	// resolution algorithm is subtle and surprising (changing the order
+	// in which fields appear in the .proto source file can change the
+	// names of fields in generated code), and does not adapt well to
+	// adding new per-field methods such as setters.
+	usedNames := map[string]bool{
+		"Reset":               true,
+		"String":              true,
+		"ProtoMessage":        true,
+		"Marshal":             true,
+		"Unmarshal":           true,
+		"ExtensionRangeArray": true,
+		"ExtensionMap":        true,
+		"Descriptor":          true,
+	}
+	makeNameUnique := func(name string, hasGetter bool) string {
+		for usedNames[name] || (hasGetter && usedNames["Get"+name]) {
+			name += "_"
+		}
+		usedNames[name] = true
+		usedNames["Get"+name] = hasGetter
+		return name
+	}
+	for _, field := range message.Fields {
+		field.GoName = makeNameUnique(field.GoName, true)
+		field.GoIdent.GoName = message.GoIdent.GoName + "_" + field.GoName
+		if field.Oneof != nil && field.Oneof.Fields[0] == field {
+			// Make the name for a oneof unique as well. For historical reasons,
+			// this assumes that a getter method is not generated for oneofs.
+			// This is incorrect, but fixing it breaks existing code.
+			field.Oneof.GoName = makeNameUnique(field.Oneof.GoName, false)
+			field.Oneof.GoIdent.GoName = message.GoIdent.GoName + "_" + field.Oneof.GoName
+		}
+	}
+
+	// Oneof field name conflict resolution.
+	//
+	// This conflict resolution is incomplete as it does not consider collisions
+	// with other oneof field types, but fixing it breaks existing code.
+	for _, field := range message.Fields {
+		if field.Oneof != nil {
+		Loop:
+			for {
+				for _, nestedMessage := range message.Messages {
+					if nestedMessage.GoIdent == field.GoIdent {
+						field.GoIdent.GoName += "_"
+						continue Loop
+					}
+				}
+				for _, nestedEnum := range message.Enums {
+					if nestedEnum.GoIdent == field.GoIdent {
+						field.GoIdent.GoName += "_"
+						continue Loop
+					}
+				}
+				break Loop
+			}
+		}
+	}
+
+	return message
+}
+
+func (message *Message) resolveDependencies(gen *Plugin) error {
+	for _, field := range message.Fields {
+		if err := field.resolveDependencies(gen); err != nil {
+			return err
+		}
+	}
+	for _, message := range message.Messages {
+		if err := message.resolveDependencies(gen); err != nil {
+			return err
+		}
+	}
+	for _, extension := range message.Extensions {
+		if err := extension.resolveDependencies(gen); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// A Field describes a message field.
+type Field struct {
+	Desc protoreflect.FieldDescriptor
+
+	// GoName is the base name of this field's Go field and methods.
+	// For code generated by protoc-gen-go, this means a field named
+	// '{{GoName}}' and a getter method named 'Get{{GoName}}'.
+	GoName string // e.g., "FieldName"
+
+	// GoIdent is the base name of a top-level declaration for this field.
+	// For code generated by protoc-gen-go, this means a wrapper type named
+	// '{{GoIdent}}' for members fields of a oneof, and a variable named
+	// 'E_{{GoIdent}}' for extension fields.
+	GoIdent GoIdent // e.g., "MessageName_FieldName"
+
+	Parent   *Message // message in which this field is declared; nil if top-level extension
+	Oneof    *Oneof   // containing oneof; nil if not part of a oneof
+	Extendee *Message // extended message for extension fields; nil otherwise
+
+	Enum    *Enum    // type for enum fields; nil otherwise
+	Message *Message // type for message or group fields; nil otherwise
+
+	Location Location   // location of this field
+	Comments CommentSet // comments associated with this field
+}
+
+func newField(gen *Plugin, f *File, message *Message, desc protoreflect.FieldDescriptor) *Field {
+	var loc Location
+	switch {
+	case desc.IsExtension() && message == nil:
+		loc = f.location.appendPath(genid.FileDescriptorProto_Extension_field_number, desc.Index())
+	case desc.IsExtension() && message != nil:
+		loc = message.Location.appendPath(genid.DescriptorProto_Extension_field_number, desc.Index())
+	default:
+		loc = message.Location.appendPath(genid.DescriptorProto_Field_field_number, desc.Index())
+	}
+	camelCased := strs.GoCamelCase(string(desc.Name()))
+	var parentPrefix string
+	if message != nil {
+		parentPrefix = message.GoIdent.GoName + "_"
+	}
+	field := &Field{
+		Desc:   desc,
+		GoName: camelCased,
+		GoIdent: GoIdent{
+			GoImportPath: f.GoImportPath,
+			GoName:       parentPrefix + camelCased,
+		},
+		Parent:   message,
+		Location: loc,
+		Comments: makeCommentSet(f.Desc.SourceLocations().ByDescriptor(desc)),
+	}
+	return field
+}
+
+func (field *Field) resolveDependencies(gen *Plugin) error {
+	desc := field.Desc
+	switch desc.Kind() {
+	case protoreflect.EnumKind:
+		name := field.Desc.Enum().FullName()
+		enum, ok := gen.enumsByName[name]
+		if !ok {
+			return fmt.Errorf("field %v: no descriptor for enum %v", desc.FullName(), name)
+		}
+		field.Enum = enum
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		name := desc.Message().FullName()
+		message, ok := gen.messagesByName[name]
+		if !ok {
+			return fmt.Errorf("field %v: no descriptor for type %v", desc.FullName(), name)
+		}
+		field.Message = message
+	}
+	if desc.IsExtension() {
+		name := desc.ContainingMessage().FullName()
+		message, ok := gen.messagesByName[name]
+		if !ok {
+			return fmt.Errorf("field %v: no descriptor for type %v", desc.FullName(), name)
+		}
+		field.Extendee = message
+	}
+	return nil
+}
+
+// A Oneof describes a message oneof.
+type Oneof struct {
+	Desc protoreflect.OneofDescriptor
+
+	// GoName is the base name of this oneof's Go field and methods.
+	// For code generated by protoc-gen-go, this means a field named
+	// '{{GoName}}' and a getter method named 'Get{{GoName}}'.
+	GoName string // e.g., "OneofName"
+
+	// GoIdent is the base name of a top-level declaration for this oneof.
+	GoIdent GoIdent // e.g., "MessageName_OneofName"
+
+	Parent *Message // message in which this oneof is declared
+
+	Fields []*Field // fields that are part of this oneof
+
+	Location Location   // location of this oneof
+	Comments CommentSet // comments associated with this oneof
+}
+
+func newOneof(gen *Plugin, f *File, message *Message, desc protoreflect.OneofDescriptor) *Oneof {
+	loc := message.Location.appendPath(genid.DescriptorProto_OneofDecl_field_number, desc.Index())
+	camelCased := strs.GoCamelCase(string(desc.Name()))
+	parentPrefix := message.GoIdent.GoName + "_"
+	return &Oneof{
+		Desc:   desc,
+		Parent: message,
+		GoName: camelCased,
+		GoIdent: GoIdent{
+			GoImportPath: f.GoImportPath,
+			GoName:       parentPrefix + camelCased,
+		},
+		Location: loc,
+		Comments: makeCommentSet(f.Desc.SourceLocations().ByDescriptor(desc)),
+	}
+}
+
+// Extension is an alias of Field for documentation.
+type Extension = Field
+
+// A Service describes a service.
+type Service struct {
+	Desc protoreflect.ServiceDescriptor
+
+	GoName string
+
+	Methods []*Method // service method declarations
+
+	Location Location   // location of this service
+	Comments CommentSet // comments associated with this service
+}
+
+func newService(gen *Plugin, f *File, desc protoreflect.ServiceDescriptor) *Service {
+	loc := f.location.appendPath(genid.FileDescriptorProto_Service_field_number, desc.Index())
+	service := &Service{
+		Desc:     desc,
+		GoName:   strs.GoCamelCase(string(desc.Name())),
+		Location: loc,
+		Comments: makeCommentSet(f.Desc.SourceLocations().ByDescriptor(desc)),
+	}
+	for i, mds := 0, desc.Methods(); i < mds.Len(); i++ {
+		service.Methods = append(service.Methods, newMethod(gen, f, service, mds.Get(i)))
+	}
+	return service
+}
+
+// A Method describes a method in a service.
+type Method struct {
+	Desc protoreflect.MethodDescriptor
+
+	GoName string
+
+	Parent *Service // service in which this method is declared
+
+	Input  *Message
+	Output *Message
+
+	Location Location   // location of this method
+	Comments CommentSet // comments associated with this method
+}
+
+func newMethod(gen *Plugin, f *File, service *Service, desc protoreflect.MethodDescriptor) *Method {
+	loc := service.Location.appendPath(genid.ServiceDescriptorProto_Method_field_number, desc.Index())
+	method := &Method{
+		Desc:     desc,
+		GoName:   strs.GoCamelCase(string(desc.Name())),
+		Parent:   service,
+		Location: loc,
+		Comments: makeCommentSet(f.Desc.SourceLocations().ByDescriptor(desc)),
+	}
+	return method
+}
+
+func (method *Method) resolveDependencies(gen *Plugin) error {
+	desc := method.Desc
+
+	inName := desc.Input().FullName()
+	in, ok := gen.messagesByName[inName]
+	if !ok {
+		return fmt.Errorf("method %v: no descriptor for type %v", desc.FullName(), inName)
+	}
+	method.Input = in
+
+	outName := desc.Output().FullName()
+	out, ok := gen.messagesByName[outName]
+	if !ok {
+		return fmt.Errorf("method %v: no descriptor for type %v", desc.FullName(), outName)
+	}
+	method.Output = out
+
+	return nil
+}
+
+// A GeneratedFile is a generated file.
+type GeneratedFile struct {
+	gen              *Plugin
+	skip             bool
+	filename         string
+	goImportPath     GoImportPath
+	buf              bytes.Buffer
+	packageNames     map[GoImportPath]GoPackageName
+	usedPackageNames map[GoPackageName]bool
+	manualImports    map[GoImportPath]bool
+	annotations      map[string][]Location
+}
+
+// NewGeneratedFile creates a new generated file with the given filename
+// and import path.
+func (gen *Plugin) NewGeneratedFile(filename string, goImportPath GoImportPath) *GeneratedFile {
+	g := &GeneratedFile{
+		gen:              gen,
+		filename:         filename,
+		goImportPath:     goImportPath,
+		packageNames:     make(map[GoImportPath]GoPackageName),
+		usedPackageNames: make(map[GoPackageName]bool),
+		manualImports:    make(map[GoImportPath]bool),
+		annotations:      make(map[string][]Location),
+	}
+
+	// All predeclared identifiers in Go are already used.
+	for _, s := range types.Universe.Names() {
+		g.usedPackageNames[GoPackageName(s)] = true
+	}
+
+	gen.genFiles = append(gen.genFiles, g)
+	return g
+}
+
+// P prints a line to the generated output. It converts each parameter to a
+// string following the same rules as fmt.Print. It never inserts spaces
+// between parameters.
+func (g *GeneratedFile) P(v ...interface{}) {
+	for _, x := range v {
+		switch x := x.(type) {
+		case GoIdent:
+			fmt.Fprint(&g.buf, g.QualifiedGoIdent(x))
+		default:
+			fmt.Fprint(&g.buf, x)
+		}
+	}
+	fmt.Fprintln(&g.buf)
+}
+
+// QualifiedGoIdent returns the string to use for a Go identifier.
+//
+// If the identifier is from a different Go package than the generated file,
+// the returned name will be qualified (package.name) and an import statement
+// for the identifier's package will be included in the file.
+func (g *GeneratedFile) QualifiedGoIdent(ident GoIdent) string {
+	if ident.GoImportPath == g.goImportPath {
+		return ident.GoName
+	}
+	if packageName, ok := g.packageNames[ident.GoImportPath]; ok {
+		return string(packageName) + "." + ident.GoName
+	}
+	packageName := cleanPackageName(path.Base(string(ident.GoImportPath)))
+	for i, orig := 1, packageName; g.usedPackageNames[packageName]; i++ {
+		packageName = orig + GoPackageName(strconv.Itoa(i))
+	}
+	g.packageNames[ident.GoImportPath] = packageName
+	g.usedPackageNames[packageName] = true
+	return string(packageName) + "." + ident.GoName
+}
+
+// Import ensures a package is imported by the generated file.
+//
+// Packages referenced by QualifiedGoIdent are automatically imported.
+// Explicitly importing a package with Import is generally only necessary
+// when the import will be blank (import _ "package").
+func (g *GeneratedFile) Import(importPath GoImportPath) {
+	g.manualImports[importPath] = true
+}
+
+// Write implements io.Writer.
+func (g *GeneratedFile) Write(p []byte) (n int, err error) {
+	return g.buf.Write(p)
+}
+
+// Skip removes the generated file from the plugin output.
+func (g *GeneratedFile) Skip() {
+	g.skip = true
+}
+
+// Unskip reverts a previous call to Skip, re-including the generated file in
+// the plugin output.
+func (g *GeneratedFile) Unskip() {
+	g.skip = false
+}
+
+// Annotate associates a symbol in a generated Go file with a location in a
+// source .proto file.
+//
+// The symbol may refer to a type, constant, variable, function, method, or
+// struct field.  The "T.sel" syntax is used to identify the method or field
+// 'sel' on type 'T'.
+func (g *GeneratedFile) Annotate(symbol string, loc Location) {
+	g.annotations[symbol] = append(g.annotations[symbol], loc)
+}
+
+// Content returns the contents of the generated file.
+func (g *GeneratedFile) Content() ([]byte, error) {
+	if !strings.HasSuffix(g.filename, ".go") {
+		return g.buf.Bytes(), nil
+	}
+
+	// Reformat generated code.
+	original := g.buf.Bytes()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "", original, parser.ParseComments)
+	if err != nil {
+		// Print out the bad code with line numbers.
+		// This should never happen in practice, but it can while changing generated code
+		// so consider this a debugging aid.
+		var src bytes.Buffer
+		s := bufio.NewScanner(bytes.NewReader(original))
+		for line := 1; s.Scan(); line++ {
+			fmt.Fprintf(&src, "%5d\t%s\n", line, s.Bytes())
+		}
+		return nil, fmt.Errorf("%v: unparsable Go source: %v\n%v", g.filename, err, src.String())
+	}
+
+	// Collect a sorted list of all imports.
+	var importPaths [][2]string
+	rewriteImport := func(importPath string) string {
+		if f := g.gen.opts.ImportRewriteFunc; f != nil {
+			return string(f(GoImportPath(importPath)))
+		}
+		return importPath
+	}
+	for importPath := range g.packageNames {
+		pkgName := string(g.packageNames[GoImportPath(importPath)])
+		pkgPath := rewriteImport(string(importPath))
+		importPaths = append(importPaths, [2]string{pkgName, pkgPath})
+	}
+	for importPath := range g.manualImports {
+		if _, ok := g.packageNames[importPath]; !ok {
+			pkgPath := rewriteImport(string(importPath))
+			importPaths = append(importPaths, [2]string{"_", pkgPath})
+		}
+	}
+	sort.Slice(importPaths, func(i, j int) bool {
+		return importPaths[i][1] < importPaths[j][1]
+	})
+
+	// Modify the AST to include a new import block.
+	if len(importPaths) > 0 {
+		// Insert block after package statement or
+		// possible comment attached to the end of the package statement.
+		pos := file.Package
+		tokFile := fset.File(file.Package)
+		pkgLine := tokFile.Line(file.Package)
+		for _, c := range file.Comments {
+			if tokFile.Line(c.Pos()) > pkgLine {
+				break
+			}
+			pos = c.End()
+		}
+
+		// Construct the import block.
+		impDecl := &ast.GenDecl{
+			Tok:    token.IMPORT,
+			TokPos: pos,
+			Lparen: pos,
+			Rparen: pos,
+		}
+		for _, importPath := range importPaths {
+			impDecl.Specs = append(impDecl.Specs, &ast.ImportSpec{
+				Name: &ast.Ident{
+					Name:    importPath[0],
+					NamePos: pos,
+				},
+				Path: &ast.BasicLit{
+					Kind:     token.STRING,
+					Value:    strconv.Quote(importPath[1]),
+					ValuePos: pos,
+				},
+				EndPos: pos,
+			})
+		}
+		file.Decls = append([]ast.Decl{impDecl}, file.Decls...)
+	}
+
+	var out bytes.Buffer
+	if err = (&printer.Config{Mode: printer.TabIndent | printer.UseSpaces, Tabwidth: 8}).Fprint(&out, fset, file); err != nil {
+		return nil, fmt.Errorf("%v: can not reformat Go source: %v", g.filename, err)
+	}
+	return out.Bytes(), nil
+}
+
+// metaFile returns the contents of the file's metadata file, which is a
+// text formatted string of the google.protobuf.GeneratedCodeInfo.
+func (g *GeneratedFile) metaFile(content []byte) (string, error) {
+	fset := token.NewFileSet()
+	astFile, err := parser.ParseFile(fset, "", content, 0)
+	if err != nil {
+		return "", err
+	}
+	info := &descriptorpb.GeneratedCodeInfo{}
+
+	seenAnnotations := make(map[string]bool)
+	annotate := func(s string, ident *ast.Ident) {
+		seenAnnotations[s] = true
+		for _, loc := range g.annotations[s] {
+			info.Annotation = append(info.Annotation, &descriptorpb.GeneratedCodeInfo_Annotation{
+				SourceFile: proto.String(loc.SourceFile),
+				Path:       loc.Path,
+				Begin:      proto.Int32(int32(fset.Position(ident.Pos()).Offset)),
+				End:        proto.Int32(int32(fset.Position(ident.End()).Offset)),
+			})
+		}
+	}
+	for _, decl := range astFile.Decls {
+		switch decl := decl.(type) {
+		case *ast.GenDecl:
+			for _, spec := range decl.Specs {
+				switch spec := spec.(type) {
+				case *ast.TypeSpec:
+					annotate(spec.Name.Name, spec.Name)
+					switch st := spec.Type.(type) {
+					case *ast.StructType:
+						for _, field := range st.Fields.List {
+							for _, name := range field.Names {
+								annotate(spec.Name.Name+"."+name.Name, name)
+							}
+						}
+					case *ast.InterfaceType:
+						for _, field := range st.Methods.List {
+							for _, name := range field.Names {
+								annotate(spec.Name.Name+"."+name.Name, name)
+							}
+						}
+					}
+				case *ast.ValueSpec:
+					for _, name := range spec.Names {
+						annotate(name.Name, name)
+					}
+				}
+			}
+		case *ast.FuncDecl:
+			if decl.Recv == nil {
+				annotate(decl.Name.Name, decl.Name)
+			} else {
+				recv := decl.Recv.List[0].Type
+				if s, ok := recv.(*ast.StarExpr); ok {
+					recv = s.X
+				}
+				if id, ok := recv.(*ast.Ident); ok {
+					annotate(id.Name+"."+decl.Name.Name, decl.Name)
+				}
+			}
+		}
+	}
+	for a := range g.annotations {
+		if !seenAnnotations[a] {
+			return "", fmt.Errorf("%v: no symbol matching annotation %q", g.filename, a)
+		}
+	}
+
+	b, err := prototext.Marshal(info)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// A GoIdent is a Go identifier, consisting of a name and import path.
+// The name is a single identifier and may not be a dot-qualified selector.
+type GoIdent struct {
+	GoName       string
+	GoImportPath GoImportPath
+}
+
+func (id GoIdent) String() string { return fmt.Sprintf("%q.%v", id.GoImportPath, id.GoName) }
+
+// newGoIdent returns the Go identifier for a descriptor.
+func newGoIdent(f *File, d protoreflect.Descriptor) GoIdent {
+	name := strings.TrimPrefix(string(d.FullName()), string(f.Desc.Package())+".")
+	return GoIdent{
+		GoName:       strs.GoCamelCase(name),
+		GoImportPath: f.GoImportPath,
+	}
+}
+
+// A GoImportPath is the import path of a Go package.
+// For example: "google.golang.org/protobuf/compiler/protogen"
+type GoImportPath string
+
+func (p GoImportPath) String() string { return strconv.Quote(string(p)) }
+
+// Ident returns a GoIdent with s as the GoName and p as the GoImportPath.
+func (p GoImportPath) Ident(s string) GoIdent {
+	return GoIdent{GoName: s, GoImportPath: p}
+}
+
+// A GoPackageName is the name of a Go package. e.g., "protobuf".
+type GoPackageName string
+
+// cleanPackageName converts a string to a valid Go package name.
+func cleanPackageName(name string) GoPackageName {
+	return GoPackageName(strs.GoSanitized(name))
+}
+
+type pathType int
+
+const (
+	pathTypeImport pathType = iota
+	pathTypeSourceRelative
+)
+
+// A Location is a location in a .proto source file.
+//
+// See the google.protobuf.SourceCodeInfo documentation in descriptor.proto
+// for details.
+type Location struct {
+	SourceFile string
+	Path       protoreflect.SourcePath
+}
+
+// appendPath add elements to a Location's path, returning a new Location.
+func (loc Location) appendPath(num protoreflect.FieldNumber, idx int) Location {
+	loc.Path = append(protoreflect.SourcePath(nil), loc.Path...) // make copy
+	loc.Path = append(loc.Path, int32(num), int32(idx))
+	return loc
+}
+
+// CommentSet is a set of leading and trailing comments associated
+// with a .proto descriptor declaration.
+type CommentSet struct {
+	LeadingDetached []Comments
+	Leading         Comments
+	Trailing        Comments
+}
+
+func makeCommentSet(loc protoreflect.SourceLocation) CommentSet {
+	var leadingDetached []Comments
+	for _, s := range loc.LeadingDetachedComments {
+		leadingDetached = append(leadingDetached, Comments(s))
+	}
+	return CommentSet{
+		LeadingDetached: leadingDetached,
+		Leading:         Comments(loc.LeadingComments),
+		Trailing:        Comments(loc.TrailingComments),
+	}
+}
+
+// Comments is a comments string as provided by protoc.
+type Comments string
+
+// String formats the comments by inserting // to the start of each line,
+// ensuring that there is a trailing newline.
+// An empty comment is formatted as an empty string.
+func (c Comments) String() string {
+	if c == "" {
+		return ""
+	}
+	var b []byte
+	for _, line := range strings.Split(strings.TrimSuffix(string(c), "\n"), "\n") {
+		b = append(b, "//"...)
+		b = append(b, line...)
+		b = append(b, "\n"...)
+	}
+	return string(b)
+}

--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
+++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc.go
@@ -1,0 +1,276 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package protodesc provides functionality for converting
+// FileDescriptorProto messages to/from protoreflect.FileDescriptor values.
+//
+// The google.protobuf.FileDescriptorProto is a protobuf message that describes
+// the type information for a .proto file in a form that is easily serializable.
+// The protoreflect.FileDescriptor is a more structured representation of
+// the FileDescriptorProto message where references and remote dependencies
+// can be directly followed.
+package protodesc
+
+import (
+	"google.golang.org/protobuf/internal/errors"
+	"google.golang.org/protobuf/internal/filedesc"
+	"google.golang.org/protobuf/internal/pragma"
+	"google.golang.org/protobuf/internal/strs"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// Resolver is the resolver used by NewFile to resolve dependencies.
+// The enums and messages provided must belong to some parent file,
+// which is also registered.
+//
+// It is implemented by protoregistry.Files.
+type Resolver interface {
+	FindFileByPath(string) (protoreflect.FileDescriptor, error)
+	FindDescriptorByName(protoreflect.FullName) (protoreflect.Descriptor, error)
+}
+
+// FileOptions configures the construction of file descriptors.
+type FileOptions struct {
+	pragma.NoUnkeyedLiterals
+
+	// AllowUnresolvable configures New to permissively allow unresolvable
+	// file, enum, or message dependencies. Unresolved dependencies are replaced
+	// by placeholder equivalents.
+	//
+	// The following dependencies may be left unresolved:
+	//	• Resolving an imported file.
+	//	• Resolving the type for a message field or extension field.
+	//	If the kind of the field is unknown, then a placeholder is used for both
+	//	the Enum and Message accessors on the protoreflect.FieldDescriptor.
+	//	• Resolving an enum value set as the default for an optional enum field.
+	//	If unresolvable, the protoreflect.FieldDescriptor.Default is set to the
+	//	first value in the associated enum (or zero if the also enum dependency
+	//	is also unresolvable). The protoreflect.FieldDescriptor.DefaultEnumValue
+	//	is populated with a placeholder.
+	//	• Resolving the extended message type for an extension field.
+	//	• Resolving the input or output message type for a service method.
+	//
+	// If the unresolved dependency uses a relative name,
+	// then the placeholder will contain an invalid FullName with a "*." prefix,
+	// indicating that the starting prefix of the full name is unknown.
+	AllowUnresolvable bool
+}
+
+// NewFile creates a new protoreflect.FileDescriptor from the provided
+// file descriptor message. See FileOptions.New for more information.
+func NewFile(fd *descriptorpb.FileDescriptorProto, r Resolver) (protoreflect.FileDescriptor, error) {
+	return FileOptions{}.New(fd, r)
+}
+
+// NewFiles creates a new protoregistry.Files from the provided
+// FileDescriptorSet message. See FileOptions.NewFiles for more information.
+func NewFiles(fd *descriptorpb.FileDescriptorSet) (*protoregistry.Files, error) {
+	return FileOptions{}.NewFiles(fd)
+}
+
+// New creates a new protoreflect.FileDescriptor from the provided
+// file descriptor message. The file must represent a valid proto file according
+// to protobuf semantics. The returned descriptor is a deep copy of the input.
+//
+// Any imported files, enum types, or message types referenced in the file are
+// resolved using the provided registry. When looking up an import file path,
+// the path must be unique. The newly created file descriptor is not registered
+// back into the provided file registry.
+func (o FileOptions) New(fd *descriptorpb.FileDescriptorProto, r Resolver) (protoreflect.FileDescriptor, error) {
+	if r == nil {
+		r = (*protoregistry.Files)(nil) // empty resolver
+	}
+
+	// Handle the file descriptor content.
+	f := &filedesc.File{L2: &filedesc.FileL2{}}
+	switch fd.GetSyntax() {
+	case "proto2", "":
+		f.L1.Syntax = protoreflect.Proto2
+	case "proto3":
+		f.L1.Syntax = protoreflect.Proto3
+	default:
+		return nil, errors.New("invalid syntax: %q", fd.GetSyntax())
+	}
+	f.L1.Path = fd.GetName()
+	if f.L1.Path == "" {
+		return nil, errors.New("file path must be populated")
+	}
+	f.L1.Package = protoreflect.FullName(fd.GetPackage())
+	if !f.L1.Package.IsValid() && f.L1.Package != "" {
+		return nil, errors.New("invalid package: %q", f.L1.Package)
+	}
+	if opts := fd.GetOptions(); opts != nil {
+		opts = proto.Clone(opts).(*descriptorpb.FileOptions)
+		f.L2.Options = func() protoreflect.ProtoMessage { return opts }
+	}
+
+	f.L2.Imports = make(filedesc.FileImports, len(fd.GetDependency()))
+	for _, i := range fd.GetPublicDependency() {
+		if !(0 <= i && int(i) < len(f.L2.Imports)) || f.L2.Imports[i].IsPublic {
+			return nil, errors.New("invalid or duplicate public import index: %d", i)
+		}
+		f.L2.Imports[i].IsPublic = true
+	}
+	for _, i := range fd.GetWeakDependency() {
+		if !(0 <= i && int(i) < len(f.L2.Imports)) || f.L2.Imports[i].IsWeak {
+			return nil, errors.New("invalid or duplicate weak import index: %d", i)
+		}
+		f.L2.Imports[i].IsWeak = true
+	}
+	imps := importSet{f.Path(): true}
+	for i, path := range fd.GetDependency() {
+		imp := &f.L2.Imports[i]
+		f, err := r.FindFileByPath(path)
+		if err == protoregistry.NotFound && (o.AllowUnresolvable || imp.IsWeak) {
+			f = filedesc.PlaceholderFile(path)
+		} else if err != nil {
+			return nil, errors.New("could not resolve import %q: %v", path, err)
+		}
+		imp.FileDescriptor = f
+
+		if imps[imp.Path()] {
+			return nil, errors.New("already imported %q", path)
+		}
+		imps[imp.Path()] = true
+	}
+	for i := range fd.GetDependency() {
+		imp := &f.L2.Imports[i]
+		imps.importPublic(imp.Imports())
+	}
+
+	// Handle source locations.
+	f.L2.Locations.File = f
+	for _, loc := range fd.GetSourceCodeInfo().GetLocation() {
+		var l protoreflect.SourceLocation
+		// TODO: Validate that the path points to an actual declaration?
+		l.Path = protoreflect.SourcePath(loc.GetPath())
+		s := loc.GetSpan()
+		switch len(s) {
+		case 3:
+			l.StartLine, l.StartColumn, l.EndLine, l.EndColumn = int(s[0]), int(s[1]), int(s[0]), int(s[2])
+		case 4:
+			l.StartLine, l.StartColumn, l.EndLine, l.EndColumn = int(s[0]), int(s[1]), int(s[2]), int(s[3])
+		default:
+			return nil, errors.New("invalid span: %v", s)
+		}
+		// TODO: Validate that the span information is sensible?
+		// See https://github.com/protocolbuffers/protobuf/issues/6378.
+		if false && (l.EndLine < l.StartLine || l.StartLine < 0 || l.StartColumn < 0 || l.EndColumn < 0 ||
+			(l.StartLine == l.EndLine && l.EndColumn <= l.StartColumn)) {
+			return nil, errors.New("invalid span: %v", s)
+		}
+		l.LeadingDetachedComments = loc.GetLeadingDetachedComments()
+		l.LeadingComments = loc.GetLeadingComments()
+		l.TrailingComments = loc.GetTrailingComments()
+		f.L2.Locations.List = append(f.L2.Locations.List, l)
+	}
+
+	// Step 1: Allocate and derive the names for all declarations.
+	// This copies all fields from the descriptor proto except:
+	//	google.protobuf.FieldDescriptorProto.type_name
+	//	google.protobuf.FieldDescriptorProto.default_value
+	//	google.protobuf.FieldDescriptorProto.oneof_index
+	//	google.protobuf.FieldDescriptorProto.extendee
+	//	google.protobuf.MethodDescriptorProto.input
+	//	google.protobuf.MethodDescriptorProto.output
+	var err error
+	sb := new(strs.Builder)
+	r1 := make(descsByName)
+	if f.L1.Enums.List, err = r1.initEnumDeclarations(fd.GetEnumType(), f, sb); err != nil {
+		return nil, err
+	}
+	if f.L1.Messages.List, err = r1.initMessagesDeclarations(fd.GetMessageType(), f, sb); err != nil {
+		return nil, err
+	}
+	if f.L1.Extensions.List, err = r1.initExtensionDeclarations(fd.GetExtension(), f, sb); err != nil {
+		return nil, err
+	}
+	if f.L1.Services.List, err = r1.initServiceDeclarations(fd.GetService(), f, sb); err != nil {
+		return nil, err
+	}
+
+	// Step 2: Resolve every dependency reference not handled by step 1.
+	r2 := &resolver{local: r1, remote: r, imports: imps, allowUnresolvable: o.AllowUnresolvable}
+	if err := r2.resolveMessageDependencies(f.L1.Messages.List, fd.GetMessageType()); err != nil {
+		return nil, err
+	}
+	if err := r2.resolveExtensionDependencies(f.L1.Extensions.List, fd.GetExtension()); err != nil {
+		return nil, err
+	}
+	if err := r2.resolveServiceDependencies(f.L1.Services.List, fd.GetService()); err != nil {
+		return nil, err
+	}
+
+	// Step 3: Validate every enum, message, and extension declaration.
+	if err := validateEnumDeclarations(f.L1.Enums.List, fd.GetEnumType()); err != nil {
+		return nil, err
+	}
+	if err := validateMessageDeclarations(f.L1.Messages.List, fd.GetMessageType()); err != nil {
+		return nil, err
+	}
+	if err := validateExtensionDeclarations(f.L1.Extensions.List, fd.GetExtension()); err != nil {
+		return nil, err
+	}
+
+	return f, nil
+}
+
+type importSet map[string]bool
+
+func (is importSet) importPublic(imps protoreflect.FileImports) {
+	for i := 0; i < imps.Len(); i++ {
+		if imp := imps.Get(i); imp.IsPublic {
+			is[imp.Path()] = true
+			is.importPublic(imp.Imports())
+		}
+	}
+}
+
+// NewFiles creates a new protoregistry.Files from the provided
+// FileDescriptorSet message. The descriptor set must include only
+// valid files according to protobuf semantics. The returned descriptors
+// are a deep copy of the input.
+func (o FileOptions) NewFiles(fds *descriptorpb.FileDescriptorSet) (*protoregistry.Files, error) {
+	files := make(map[string]*descriptorpb.FileDescriptorProto)
+	for _, fd := range fds.File {
+		if _, ok := files[fd.GetName()]; ok {
+			return nil, errors.New("file appears multiple times: %q", fd.GetName())
+		}
+		files[fd.GetName()] = fd
+	}
+	r := &protoregistry.Files{}
+	for _, fd := range files {
+		if err := o.addFileDeps(r, fd, files); err != nil {
+			return nil, err
+		}
+	}
+	return r, nil
+}
+func (o FileOptions) addFileDeps(r *protoregistry.Files, fd *descriptorpb.FileDescriptorProto, files map[string]*descriptorpb.FileDescriptorProto) error {
+	// Set the entry to nil while descending into a file's dependencies to detect cycles.
+	files[fd.GetName()] = nil
+	for _, dep := range fd.Dependency {
+		depfd, ok := files[dep]
+		if depfd == nil {
+			if ok {
+				return errors.New("import cycle in file: %q", dep)
+			}
+			continue
+		}
+		if err := o.addFileDeps(r, depfd, files); err != nil {
+			return err
+		}
+	}
+	// Delete the entry once dependencies are processed.
+	delete(files, fd.GetName())
+	f, err := o.New(fd, r)
+	if err != nil {
+		return err
+	}
+	return r.RegisterFile(f)
+}

--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go
+++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_init.go
@@ -1,0 +1,248 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package protodesc
+
+import (
+	"google.golang.org/protobuf/internal/errors"
+	"google.golang.org/protobuf/internal/filedesc"
+	"google.golang.org/protobuf/internal/strs"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+type descsByName map[protoreflect.FullName]protoreflect.Descriptor
+
+func (r descsByName) initEnumDeclarations(eds []*descriptorpb.EnumDescriptorProto, parent protoreflect.Descriptor, sb *strs.Builder) (es []filedesc.Enum, err error) {
+	es = make([]filedesc.Enum, len(eds)) // allocate up-front to ensure stable pointers
+	for i, ed := range eds {
+		e := &es[i]
+		e.L2 = new(filedesc.EnumL2)
+		if e.L0, err = r.makeBase(e, parent, ed.GetName(), i, sb); err != nil {
+			return nil, err
+		}
+		if opts := ed.GetOptions(); opts != nil {
+			opts = proto.Clone(opts).(*descriptorpb.EnumOptions)
+			e.L2.Options = func() protoreflect.ProtoMessage { return opts }
+		}
+		for _, s := range ed.GetReservedName() {
+			e.L2.ReservedNames.List = append(e.L2.ReservedNames.List, protoreflect.Name(s))
+		}
+		for _, rr := range ed.GetReservedRange() {
+			e.L2.ReservedRanges.List = append(e.L2.ReservedRanges.List, [2]protoreflect.EnumNumber{
+				protoreflect.EnumNumber(rr.GetStart()),
+				protoreflect.EnumNumber(rr.GetEnd()),
+			})
+		}
+		if e.L2.Values.List, err = r.initEnumValuesFromDescriptorProto(ed.GetValue(), e, sb); err != nil {
+			return nil, err
+		}
+	}
+	return es, nil
+}
+
+func (r descsByName) initEnumValuesFromDescriptorProto(vds []*descriptorpb.EnumValueDescriptorProto, parent protoreflect.Descriptor, sb *strs.Builder) (vs []filedesc.EnumValue, err error) {
+	vs = make([]filedesc.EnumValue, len(vds)) // allocate up-front to ensure stable pointers
+	for i, vd := range vds {
+		v := &vs[i]
+		if v.L0, err = r.makeBase(v, parent, vd.GetName(), i, sb); err != nil {
+			return nil, err
+		}
+		if opts := vd.GetOptions(); opts != nil {
+			opts = proto.Clone(opts).(*descriptorpb.EnumValueOptions)
+			v.L1.Options = func() protoreflect.ProtoMessage { return opts }
+		}
+		v.L1.Number = protoreflect.EnumNumber(vd.GetNumber())
+	}
+	return vs, nil
+}
+
+func (r descsByName) initMessagesDeclarations(mds []*descriptorpb.DescriptorProto, parent protoreflect.Descriptor, sb *strs.Builder) (ms []filedesc.Message, err error) {
+	ms = make([]filedesc.Message, len(mds)) // allocate up-front to ensure stable pointers
+	for i, md := range mds {
+		m := &ms[i]
+		m.L2 = new(filedesc.MessageL2)
+		if m.L0, err = r.makeBase(m, parent, md.GetName(), i, sb); err != nil {
+			return nil, err
+		}
+		if opts := md.GetOptions(); opts != nil {
+			opts = proto.Clone(opts).(*descriptorpb.MessageOptions)
+			m.L2.Options = func() protoreflect.ProtoMessage { return opts }
+			m.L1.IsMapEntry = opts.GetMapEntry()
+			m.L1.IsMessageSet = opts.GetMessageSetWireFormat()
+		}
+		for _, s := range md.GetReservedName() {
+			m.L2.ReservedNames.List = append(m.L2.ReservedNames.List, protoreflect.Name(s))
+		}
+		for _, rr := range md.GetReservedRange() {
+			m.L2.ReservedRanges.List = append(m.L2.ReservedRanges.List, [2]protoreflect.FieldNumber{
+				protoreflect.FieldNumber(rr.GetStart()),
+				protoreflect.FieldNumber(rr.GetEnd()),
+			})
+		}
+		for _, xr := range md.GetExtensionRange() {
+			m.L2.ExtensionRanges.List = append(m.L2.ExtensionRanges.List, [2]protoreflect.FieldNumber{
+				protoreflect.FieldNumber(xr.GetStart()),
+				protoreflect.FieldNumber(xr.GetEnd()),
+			})
+			var optsFunc func() protoreflect.ProtoMessage
+			if opts := xr.GetOptions(); opts != nil {
+				opts = proto.Clone(opts).(*descriptorpb.ExtensionRangeOptions)
+				optsFunc = func() protoreflect.ProtoMessage { return opts }
+			}
+			m.L2.ExtensionRangeOptions = append(m.L2.ExtensionRangeOptions, optsFunc)
+		}
+		if m.L2.Fields.List, err = r.initFieldsFromDescriptorProto(md.GetField(), m, sb); err != nil {
+			return nil, err
+		}
+		if m.L2.Oneofs.List, err = r.initOneofsFromDescriptorProto(md.GetOneofDecl(), m, sb); err != nil {
+			return nil, err
+		}
+		if m.L1.Enums.List, err = r.initEnumDeclarations(md.GetEnumType(), m, sb); err != nil {
+			return nil, err
+		}
+		if m.L1.Messages.List, err = r.initMessagesDeclarations(md.GetNestedType(), m, sb); err != nil {
+			return nil, err
+		}
+		if m.L1.Extensions.List, err = r.initExtensionDeclarations(md.GetExtension(), m, sb); err != nil {
+			return nil, err
+		}
+	}
+	return ms, nil
+}
+
+func (r descsByName) initFieldsFromDescriptorProto(fds []*descriptorpb.FieldDescriptorProto, parent protoreflect.Descriptor, sb *strs.Builder) (fs []filedesc.Field, err error) {
+	fs = make([]filedesc.Field, len(fds)) // allocate up-front to ensure stable pointers
+	for i, fd := range fds {
+		f := &fs[i]
+		if f.L0, err = r.makeBase(f, parent, fd.GetName(), i, sb); err != nil {
+			return nil, err
+		}
+		f.L1.IsProto3Optional = fd.GetProto3Optional()
+		if opts := fd.GetOptions(); opts != nil {
+			opts = proto.Clone(opts).(*descriptorpb.FieldOptions)
+			f.L1.Options = func() protoreflect.ProtoMessage { return opts }
+			f.L1.IsWeak = opts.GetWeak()
+			f.L1.HasPacked = opts.Packed != nil
+			f.L1.IsPacked = opts.GetPacked()
+		}
+		f.L1.Number = protoreflect.FieldNumber(fd.GetNumber())
+		f.L1.Cardinality = protoreflect.Cardinality(fd.GetLabel())
+		if fd.Type != nil {
+			f.L1.Kind = protoreflect.Kind(fd.GetType())
+		}
+		if fd.JsonName != nil {
+			f.L1.StringName.InitJSON(fd.GetJsonName())
+		}
+	}
+	return fs, nil
+}
+
+func (r descsByName) initOneofsFromDescriptorProto(ods []*descriptorpb.OneofDescriptorProto, parent protoreflect.Descriptor, sb *strs.Builder) (os []filedesc.Oneof, err error) {
+	os = make([]filedesc.Oneof, len(ods)) // allocate up-front to ensure stable pointers
+	for i, od := range ods {
+		o := &os[i]
+		if o.L0, err = r.makeBase(o, parent, od.GetName(), i, sb); err != nil {
+			return nil, err
+		}
+		if opts := od.GetOptions(); opts != nil {
+			opts = proto.Clone(opts).(*descriptorpb.OneofOptions)
+			o.L1.Options = func() protoreflect.ProtoMessage { return opts }
+		}
+	}
+	return os, nil
+}
+
+func (r descsByName) initExtensionDeclarations(xds []*descriptorpb.FieldDescriptorProto, parent protoreflect.Descriptor, sb *strs.Builder) (xs []filedesc.Extension, err error) {
+	xs = make([]filedesc.Extension, len(xds)) // allocate up-front to ensure stable pointers
+	for i, xd := range xds {
+		x := &xs[i]
+		x.L2 = new(filedesc.ExtensionL2)
+		if x.L0, err = r.makeBase(x, parent, xd.GetName(), i, sb); err != nil {
+			return nil, err
+		}
+		if opts := xd.GetOptions(); opts != nil {
+			opts = proto.Clone(opts).(*descriptorpb.FieldOptions)
+			x.L2.Options = func() protoreflect.ProtoMessage { return opts }
+			x.L2.IsPacked = opts.GetPacked()
+		}
+		x.L1.Number = protoreflect.FieldNumber(xd.GetNumber())
+		x.L1.Cardinality = protoreflect.Cardinality(xd.GetLabel())
+		if xd.Type != nil {
+			x.L1.Kind = protoreflect.Kind(xd.GetType())
+		}
+		if xd.JsonName != nil {
+			x.L2.StringName.InitJSON(xd.GetJsonName())
+		}
+	}
+	return xs, nil
+}
+
+func (r descsByName) initServiceDeclarations(sds []*descriptorpb.ServiceDescriptorProto, parent protoreflect.Descriptor, sb *strs.Builder) (ss []filedesc.Service, err error) {
+	ss = make([]filedesc.Service, len(sds)) // allocate up-front to ensure stable pointers
+	for i, sd := range sds {
+		s := &ss[i]
+		s.L2 = new(filedesc.ServiceL2)
+		if s.L0, err = r.makeBase(s, parent, sd.GetName(), i, sb); err != nil {
+			return nil, err
+		}
+		if opts := sd.GetOptions(); opts != nil {
+			opts = proto.Clone(opts).(*descriptorpb.ServiceOptions)
+			s.L2.Options = func() protoreflect.ProtoMessage { return opts }
+		}
+		if s.L2.Methods.List, err = r.initMethodsFromDescriptorProto(sd.GetMethod(), s, sb); err != nil {
+			return nil, err
+		}
+	}
+	return ss, nil
+}
+
+func (r descsByName) initMethodsFromDescriptorProto(mds []*descriptorpb.MethodDescriptorProto, parent protoreflect.Descriptor, sb *strs.Builder) (ms []filedesc.Method, err error) {
+	ms = make([]filedesc.Method, len(mds)) // allocate up-front to ensure stable pointers
+	for i, md := range mds {
+		m := &ms[i]
+		if m.L0, err = r.makeBase(m, parent, md.GetName(), i, sb); err != nil {
+			return nil, err
+		}
+		if opts := md.GetOptions(); opts != nil {
+			opts = proto.Clone(opts).(*descriptorpb.MethodOptions)
+			m.L1.Options = func() protoreflect.ProtoMessage { return opts }
+		}
+		m.L1.IsStreamingClient = md.GetClientStreaming()
+		m.L1.IsStreamingServer = md.GetServerStreaming()
+	}
+	return ms, nil
+}
+
+func (r descsByName) makeBase(child, parent protoreflect.Descriptor, name string, idx int, sb *strs.Builder) (filedesc.BaseL0, error) {
+	if !protoreflect.Name(name).IsValid() {
+		return filedesc.BaseL0{}, errors.New("descriptor %q has an invalid nested name: %q", parent.FullName(), name)
+	}
+
+	// Derive the full name of the child.
+	// Note that enum values are a sibling to the enum parent in the namespace.
+	var fullName protoreflect.FullName
+	if _, ok := parent.(protoreflect.EnumDescriptor); ok {
+		fullName = sb.AppendFullName(parent.FullName().Parent(), protoreflect.Name(name))
+	} else {
+		fullName = sb.AppendFullName(parent.FullName(), protoreflect.Name(name))
+	}
+	if _, ok := r[fullName]; ok {
+		return filedesc.BaseL0{}, errors.New("descriptor %q already declared", fullName)
+	}
+	r[fullName] = child
+
+	// TODO: Verify that the full name does not already exist in the resolver?
+	// This is not as critical since most usages of NewFile will register
+	// the created file back into the registry, which will perform this check.
+
+	return filedesc.BaseL0{
+		FullName:   fullName,
+		ParentFile: parent.ParentFile().(*filedesc.File),
+		Parent:     parent,
+		Index:      idx,
+	}, nil
+}

--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go
+++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_resolve.go
@@ -1,0 +1,286 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package protodesc
+
+import (
+	"google.golang.org/protobuf/internal/encoding/defval"
+	"google.golang.org/protobuf/internal/errors"
+	"google.golang.org/protobuf/internal/filedesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// resolver is a wrapper around a local registry of declarations within the file
+// and the remote resolver. The remote resolver is restricted to only return
+// descriptors that have been imported.
+type resolver struct {
+	local   descsByName
+	remote  Resolver
+	imports importSet
+
+	allowUnresolvable bool
+}
+
+func (r *resolver) resolveMessageDependencies(ms []filedesc.Message, mds []*descriptorpb.DescriptorProto) (err error) {
+	for i, md := range mds {
+		m := &ms[i]
+		for j, fd := range md.GetField() {
+			f := &m.L2.Fields.List[j]
+			if f.L1.Cardinality == protoreflect.Required {
+				m.L2.RequiredNumbers.List = append(m.L2.RequiredNumbers.List, f.L1.Number)
+			}
+			if fd.OneofIndex != nil {
+				k := int(fd.GetOneofIndex())
+				if !(0 <= k && k < len(md.GetOneofDecl())) {
+					return errors.New("message field %q has an invalid oneof index: %d", f.FullName(), k)
+				}
+				o := &m.L2.Oneofs.List[k]
+				f.L1.ContainingOneof = o
+				o.L1.Fields.List = append(o.L1.Fields.List, f)
+			}
+
+			if f.L1.Kind, f.L1.Enum, f.L1.Message, err = r.findTarget(f.Kind(), f.Parent().FullName(), partialName(fd.GetTypeName()), f.IsWeak()); err != nil {
+				return errors.New("message field %q cannot resolve type: %v", f.FullName(), err)
+			}
+			if fd.DefaultValue != nil {
+				v, ev, err := unmarshalDefault(fd.GetDefaultValue(), f, r.allowUnresolvable)
+				if err != nil {
+					return errors.New("message field %q has invalid default: %v", f.FullName(), err)
+				}
+				f.L1.Default = filedesc.DefaultValue(v, ev)
+			}
+		}
+
+		if err := r.resolveMessageDependencies(m.L1.Messages.List, md.GetNestedType()); err != nil {
+			return err
+		}
+		if err := r.resolveExtensionDependencies(m.L1.Extensions.List, md.GetExtension()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *resolver) resolveExtensionDependencies(xs []filedesc.Extension, xds []*descriptorpb.FieldDescriptorProto) (err error) {
+	for i, xd := range xds {
+		x := &xs[i]
+		if x.L1.Extendee, err = r.findMessageDescriptor(x.Parent().FullName(), partialName(xd.GetExtendee()), false); err != nil {
+			return errors.New("extension field %q cannot resolve extendee: %v", x.FullName(), err)
+		}
+		if x.L1.Kind, x.L2.Enum, x.L2.Message, err = r.findTarget(x.Kind(), x.Parent().FullName(), partialName(xd.GetTypeName()), false); err != nil {
+			return errors.New("extension field %q cannot resolve type: %v", x.FullName(), err)
+		}
+		if xd.DefaultValue != nil {
+			v, ev, err := unmarshalDefault(xd.GetDefaultValue(), x, r.allowUnresolvable)
+			if err != nil {
+				return errors.New("extension field %q has invalid default: %v", x.FullName(), err)
+			}
+			x.L2.Default = filedesc.DefaultValue(v, ev)
+		}
+	}
+	return nil
+}
+
+func (r *resolver) resolveServiceDependencies(ss []filedesc.Service, sds []*descriptorpb.ServiceDescriptorProto) (err error) {
+	for i, sd := range sds {
+		s := &ss[i]
+		for j, md := range sd.GetMethod() {
+			m := &s.L2.Methods.List[j]
+			m.L1.Input, err = r.findMessageDescriptor(m.Parent().FullName(), partialName(md.GetInputType()), false)
+			if err != nil {
+				return errors.New("service method %q cannot resolve input: %v", m.FullName(), err)
+			}
+			m.L1.Output, err = r.findMessageDescriptor(s.FullName(), partialName(md.GetOutputType()), false)
+			if err != nil {
+				return errors.New("service method %q cannot resolve output: %v", m.FullName(), err)
+			}
+		}
+	}
+	return nil
+}
+
+// findTarget finds an enum or message descriptor if k is an enum, message,
+// group, or unknown. If unknown, and the name could be resolved, the kind
+// returned kind is set based on the type of the resolved descriptor.
+func (r *resolver) findTarget(k protoreflect.Kind, scope protoreflect.FullName, ref partialName, isWeak bool) (protoreflect.Kind, protoreflect.EnumDescriptor, protoreflect.MessageDescriptor, error) {
+	switch k {
+	case protoreflect.EnumKind:
+		ed, err := r.findEnumDescriptor(scope, ref, isWeak)
+		if err != nil {
+			return 0, nil, nil, err
+		}
+		return k, ed, nil, nil
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		md, err := r.findMessageDescriptor(scope, ref, isWeak)
+		if err != nil {
+			return 0, nil, nil, err
+		}
+		return k, nil, md, nil
+	case 0:
+		// Handle unspecified kinds (possible with parsers that operate
+		// on a per-file basis without knowledge of dependencies).
+		d, err := r.findDescriptor(scope, ref)
+		if err == protoregistry.NotFound && (r.allowUnresolvable || isWeak) {
+			return k, filedesc.PlaceholderEnum(ref.FullName()), filedesc.PlaceholderMessage(ref.FullName()), nil
+		} else if err == protoregistry.NotFound {
+			return 0, nil, nil, errors.New("%q not found", ref.FullName())
+		} else if err != nil {
+			return 0, nil, nil, err
+		}
+		switch d := d.(type) {
+		case protoreflect.EnumDescriptor:
+			return protoreflect.EnumKind, d, nil, nil
+		case protoreflect.MessageDescriptor:
+			return protoreflect.MessageKind, nil, d, nil
+		default:
+			return 0, nil, nil, errors.New("unknown kind")
+		}
+	default:
+		if ref != "" {
+			return 0, nil, nil, errors.New("target name cannot be specified for %v", k)
+		}
+		if !k.IsValid() {
+			return 0, nil, nil, errors.New("invalid kind: %d", k)
+		}
+		return k, nil, nil, nil
+	}
+}
+
+// findDescriptor finds the descriptor by name,
+// which may be a relative name within some scope.
+//
+// Suppose the scope was "fizz.buzz" and the reference was "Foo.Bar",
+// then the following full names are searched:
+//   - fizz.buzz.Foo.Bar
+//   - fizz.Foo.Bar
+//   - Foo.Bar
+func (r *resolver) findDescriptor(scope protoreflect.FullName, ref partialName) (protoreflect.Descriptor, error) {
+	if !ref.IsValid() {
+		return nil, errors.New("invalid name reference: %q", ref)
+	}
+	if ref.IsFull() {
+		scope, ref = "", ref[1:]
+	}
+	var foundButNotImported protoreflect.Descriptor
+	for {
+		// Derive the full name to search.
+		s := protoreflect.FullName(ref)
+		if scope != "" {
+			s = scope + "." + s
+		}
+
+		// Check the current file for the descriptor.
+		if d, ok := r.local[s]; ok {
+			return d, nil
+		}
+
+		// Check the remote registry for the descriptor.
+		d, err := r.remote.FindDescriptorByName(s)
+		if err == nil {
+			// Only allow descriptors covered by one of the imports.
+			if r.imports[d.ParentFile().Path()] {
+				return d, nil
+			}
+			foundButNotImported = d
+		} else if err != protoregistry.NotFound {
+			return nil, errors.Wrap(err, "%q", s)
+		}
+
+		// Continue on at a higher level of scoping.
+		if scope == "" {
+			if d := foundButNotImported; d != nil {
+				return nil, errors.New("resolved %q, but %q is not imported", d.FullName(), d.ParentFile().Path())
+			}
+			return nil, protoregistry.NotFound
+		}
+		scope = scope.Parent()
+	}
+}
+
+func (r *resolver) findEnumDescriptor(scope protoreflect.FullName, ref partialName, isWeak bool) (protoreflect.EnumDescriptor, error) {
+	d, err := r.findDescriptor(scope, ref)
+	if err == protoregistry.NotFound && (r.allowUnresolvable || isWeak) {
+		return filedesc.PlaceholderEnum(ref.FullName()), nil
+	} else if err == protoregistry.NotFound {
+		return nil, errors.New("%q not found", ref.FullName())
+	} else if err != nil {
+		return nil, err
+	}
+	ed, ok := d.(protoreflect.EnumDescriptor)
+	if !ok {
+		return nil, errors.New("resolved %q, but it is not an enum", d.FullName())
+	}
+	return ed, nil
+}
+
+func (r *resolver) findMessageDescriptor(scope protoreflect.FullName, ref partialName, isWeak bool) (protoreflect.MessageDescriptor, error) {
+	d, err := r.findDescriptor(scope, ref)
+	if err == protoregistry.NotFound && (r.allowUnresolvable || isWeak) {
+		return filedesc.PlaceholderMessage(ref.FullName()), nil
+	} else if err == protoregistry.NotFound {
+		return nil, errors.New("%q not found", ref.FullName())
+	} else if err != nil {
+		return nil, err
+	}
+	md, ok := d.(protoreflect.MessageDescriptor)
+	if !ok {
+		return nil, errors.New("resolved %q, but it is not an message", d.FullName())
+	}
+	return md, nil
+}
+
+// partialName is the partial name. A leading dot means that the name is full,
+// otherwise the name is relative to some current scope.
+// See google.protobuf.FieldDescriptorProto.type_name.
+type partialName string
+
+func (s partialName) IsFull() bool {
+	return len(s) > 0 && s[0] == '.'
+}
+
+func (s partialName) IsValid() bool {
+	if s.IsFull() {
+		return protoreflect.FullName(s[1:]).IsValid()
+	}
+	return protoreflect.FullName(s).IsValid()
+}
+
+const unknownPrefix = "*."
+
+// FullName converts the partial name to a full name on a best-effort basis.
+// If relative, it creates an invalid full name, using a "*." prefix
+// to indicate that the start of the full name is unknown.
+func (s partialName) FullName() protoreflect.FullName {
+	if s.IsFull() {
+		return protoreflect.FullName(s[1:])
+	}
+	return protoreflect.FullName(unknownPrefix + s)
+}
+
+func unmarshalDefault(s string, fd protoreflect.FieldDescriptor, allowUnresolvable bool) (protoreflect.Value, protoreflect.EnumValueDescriptor, error) {
+	var evs protoreflect.EnumValueDescriptors
+	if fd.Enum() != nil {
+		evs = fd.Enum().Values()
+	}
+	v, ev, err := defval.Unmarshal(s, fd.Kind(), evs, defval.Descriptor)
+	if err != nil && allowUnresolvable && evs != nil && protoreflect.Name(s).IsValid() {
+		v = protoreflect.ValueOfEnum(0)
+		if evs.Len() > 0 {
+			v = protoreflect.ValueOfEnum(evs.Get(0).Number())
+		}
+		ev = filedesc.PlaceholderEnumValue(fd.Enum().FullName().Parent().Append(protoreflect.Name(s)))
+	} else if err != nil {
+		return v, ev, err
+	}
+	if fd.Syntax() == protoreflect.Proto3 {
+		return v, ev, errors.New("cannot be specified under proto3 semantics")
+	}
+	if fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind || fd.Cardinality() == protoreflect.Repeated {
+		return v, ev, errors.New("cannot be specified on composite types")
+	}
+	return v, ev, nil
+}

--- a/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go
+++ b/vendor/google.golang.org/protobuf/reflect/protodesc/desc_validate.go
@@ -1,0 +1,374 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package protodesc
+
+import (
+	"strings"
+	"unicode"
+
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/internal/errors"
+	"google.golang.org/protobuf/internal/filedesc"
+	"google.golang.org/protobuf/internal/flags"
+	"google.golang.org/protobuf/internal/genid"
+	"google.golang.org/protobuf/internal/strs"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+func validateEnumDeclarations(es []filedesc.Enum, eds []*descriptorpb.EnumDescriptorProto) error {
+	for i, ed := range eds {
+		e := &es[i]
+		if err := e.L2.ReservedNames.CheckValid(); err != nil {
+			return errors.New("enum %q reserved names has %v", e.FullName(), err)
+		}
+		if err := e.L2.ReservedRanges.CheckValid(); err != nil {
+			return errors.New("enum %q reserved ranges has %v", e.FullName(), err)
+		}
+		if len(ed.GetValue()) == 0 {
+			return errors.New("enum %q must contain at least one value declaration", e.FullName())
+		}
+		allowAlias := ed.GetOptions().GetAllowAlias()
+		foundAlias := false
+		for i := 0; i < e.Values().Len(); i++ {
+			v1 := e.Values().Get(i)
+			if v2 := e.Values().ByNumber(v1.Number()); v1 != v2 {
+				foundAlias = true
+				if !allowAlias {
+					return errors.New("enum %q has conflicting non-aliased values on number %d: %q with %q", e.FullName(), v1.Number(), v1.Name(), v2.Name())
+				}
+			}
+		}
+		if allowAlias && !foundAlias {
+			return errors.New("enum %q allows aliases, but none were found", e.FullName())
+		}
+		if e.Syntax() == protoreflect.Proto3 {
+			if v := e.Values().Get(0); v.Number() != 0 {
+				return errors.New("enum %q using proto3 semantics must have zero number for the first value", v.FullName())
+			}
+			// Verify that value names in proto3 do not conflict if the
+			// case-insensitive prefix is removed.
+			// See protoc v3.8.0: src/google/protobuf/descriptor.cc:4991-5055
+			names := map[string]protoreflect.EnumValueDescriptor{}
+			prefix := strings.Replace(strings.ToLower(string(e.Name())), "_", "", -1)
+			for i := 0; i < e.Values().Len(); i++ {
+				v1 := e.Values().Get(i)
+				s := strs.EnumValueName(strs.TrimEnumPrefix(string(v1.Name()), prefix))
+				if v2, ok := names[s]; ok && v1.Number() != v2.Number() {
+					return errors.New("enum %q using proto3 semantics has conflict: %q with %q", e.FullName(), v1.Name(), v2.Name())
+				}
+				names[s] = v1
+			}
+		}
+
+		for j, vd := range ed.GetValue() {
+			v := &e.L2.Values.List[j]
+			if vd.Number == nil {
+				return errors.New("enum value %q must have a specified number", v.FullName())
+			}
+			if e.L2.ReservedNames.Has(v.Name()) {
+				return errors.New("enum value %q must not use reserved name", v.FullName())
+			}
+			if e.L2.ReservedRanges.Has(v.Number()) {
+				return errors.New("enum value %q must not use reserved number %d", v.FullName(), v.Number())
+			}
+		}
+	}
+	return nil
+}
+
+func validateMessageDeclarations(ms []filedesc.Message, mds []*descriptorpb.DescriptorProto) error {
+	for i, md := range mds {
+		m := &ms[i]
+
+		// Handle the message descriptor itself.
+		isMessageSet := md.GetOptions().GetMessageSetWireFormat()
+		if err := m.L2.ReservedNames.CheckValid(); err != nil {
+			return errors.New("message %q reserved names has %v", m.FullName(), err)
+		}
+		if err := m.L2.ReservedRanges.CheckValid(isMessageSet); err != nil {
+			return errors.New("message %q reserved ranges has %v", m.FullName(), err)
+		}
+		if err := m.L2.ExtensionRanges.CheckValid(isMessageSet); err != nil {
+			return errors.New("message %q extension ranges has %v", m.FullName(), err)
+		}
+		if err := (*filedesc.FieldRanges).CheckOverlap(&m.L2.ReservedRanges, &m.L2.ExtensionRanges); err != nil {
+			return errors.New("message %q reserved and extension ranges has %v", m.FullName(), err)
+		}
+		for i := 0; i < m.Fields().Len(); i++ {
+			f1 := m.Fields().Get(i)
+			if f2 := m.Fields().ByNumber(f1.Number()); f1 != f2 {
+				return errors.New("message %q has conflicting fields: %q with %q", m.FullName(), f1.Name(), f2.Name())
+			}
+		}
+		if isMessageSet && !flags.ProtoLegacy {
+			return errors.New("message %q is a MessageSet, which is a legacy proto1 feature that is no longer supported", m.FullName())
+		}
+		if isMessageSet && (m.Syntax() != protoreflect.Proto2 || m.Fields().Len() > 0 || m.ExtensionRanges().Len() == 0) {
+			return errors.New("message %q is an invalid proto1 MessageSet", m.FullName())
+		}
+		if m.Syntax() == protoreflect.Proto3 {
+			if m.ExtensionRanges().Len() > 0 {
+				return errors.New("message %q using proto3 semantics cannot have extension ranges", m.FullName())
+			}
+			// Verify that field names in proto3 do not conflict if lowercased
+			// with all underscores removed.
+			// See protoc v3.8.0: src/google/protobuf/descriptor.cc:5830-5847
+			names := map[string]protoreflect.FieldDescriptor{}
+			for i := 0; i < m.Fields().Len(); i++ {
+				f1 := m.Fields().Get(i)
+				s := strings.Replace(strings.ToLower(string(f1.Name())), "_", "", -1)
+				if f2, ok := names[s]; ok {
+					return errors.New("message %q using proto3 semantics has conflict: %q with %q", m.FullName(), f1.Name(), f2.Name())
+				}
+				names[s] = f1
+			}
+		}
+
+		for j, fd := range md.GetField() {
+			f := &m.L2.Fields.List[j]
+			if m.L2.ReservedNames.Has(f.Name()) {
+				return errors.New("message field %q must not use reserved name", f.FullName())
+			}
+			if !f.Number().IsValid() {
+				return errors.New("message field %q has an invalid number: %d", f.FullName(), f.Number())
+			}
+			if !f.Cardinality().IsValid() {
+				return errors.New("message field %q has an invalid cardinality: %d", f.FullName(), f.Cardinality())
+			}
+			if m.L2.ReservedRanges.Has(f.Number()) {
+				return errors.New("message field %q must not use reserved number %d", f.FullName(), f.Number())
+			}
+			if m.L2.ExtensionRanges.Has(f.Number()) {
+				return errors.New("message field %q with number %d in extension range", f.FullName(), f.Number())
+			}
+			if fd.Extendee != nil {
+				return errors.New("message field %q may not have extendee: %q", f.FullName(), fd.GetExtendee())
+			}
+			if f.L1.IsProto3Optional {
+				if f.Syntax() != protoreflect.Proto3 {
+					return errors.New("message field %q under proto3 optional semantics must be specified in the proto3 syntax", f.FullName())
+				}
+				if f.Cardinality() != protoreflect.Optional {
+					return errors.New("message field %q under proto3 optional semantics must have optional cardinality", f.FullName())
+				}
+				if f.ContainingOneof() != nil && f.ContainingOneof().Fields().Len() != 1 {
+					return errors.New("message field %q under proto3 optional semantics must be within a single element oneof", f.FullName())
+				}
+			}
+			if f.IsWeak() && !flags.ProtoLegacy {
+				return errors.New("message field %q is a weak field, which is a legacy proto1 feature that is no longer supported", f.FullName())
+			}
+			if f.IsWeak() && (f.Syntax() != protoreflect.Proto2 || !isOptionalMessage(f) || f.ContainingOneof() != nil) {
+				return errors.New("message field %q may only be weak for an optional message", f.FullName())
+			}
+			if f.IsPacked() && !isPackable(f) {
+				return errors.New("message field %q is not packable", f.FullName())
+			}
+			if err := checkValidGroup(f); err != nil {
+				return errors.New("message field %q is an invalid group: %v", f.FullName(), err)
+			}
+			if err := checkValidMap(f); err != nil {
+				return errors.New("message field %q is an invalid map: %v", f.FullName(), err)
+			}
+			if f.Syntax() == protoreflect.Proto3 {
+				if f.Cardinality() == protoreflect.Required {
+					return errors.New("message field %q using proto3 semantics cannot be required", f.FullName())
+				}
+				if f.Enum() != nil && !f.Enum().IsPlaceholder() && f.Enum().Syntax() != protoreflect.Proto3 {
+					return errors.New("message field %q using proto3 semantics may only depend on a proto3 enum", f.FullName())
+				}
+			}
+		}
+		seenSynthetic := false // synthetic oneofs for proto3 optional must come after real oneofs
+		for j := range md.GetOneofDecl() {
+			o := &m.L2.Oneofs.List[j]
+			if o.Fields().Len() == 0 {
+				return errors.New("message oneof %q must contain at least one field declaration", o.FullName())
+			}
+			if n := o.Fields().Len(); n-1 != (o.Fields().Get(n-1).Index() - o.Fields().Get(0).Index()) {
+				return errors.New("message oneof %q must have consecutively declared fields", o.FullName())
+			}
+
+			if o.IsSynthetic() {
+				seenSynthetic = true
+				continue
+			}
+			if !o.IsSynthetic() && seenSynthetic {
+				return errors.New("message oneof %q must be declared before synthetic oneofs", o.FullName())
+			}
+
+			for i := 0; i < o.Fields().Len(); i++ {
+				f := o.Fields().Get(i)
+				if f.Cardinality() != protoreflect.Optional {
+					return errors.New("message field %q belongs in a oneof and must be optional", f.FullName())
+				}
+				if f.IsWeak() {
+					return errors.New("message field %q belongs in a oneof and must not be a weak reference", f.FullName())
+				}
+			}
+		}
+
+		if err := validateEnumDeclarations(m.L1.Enums.List, md.GetEnumType()); err != nil {
+			return err
+		}
+		if err := validateMessageDeclarations(m.L1.Messages.List, md.GetNestedType()); err != nil {
+			return err
+		}
+		if err := validateExtensionDeclarations(m.L1.Extensions.List, md.GetExtension()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateExtensionDeclarations(xs []filedesc.Extension, xds []*descriptorpb.FieldDescriptorProto) error {
+	for i, xd := range xds {
+		x := &xs[i]
+		// NOTE: Avoid using the IsValid method since extensions to MessageSet
+		// may have a field number higher than normal. This check only verifies
+		// that the number is not negative or reserved. We check again later
+		// if we know that the extendee is definitely not a MessageSet.
+		if n := x.Number(); n < 0 || (protowire.FirstReservedNumber <= n && n <= protowire.LastReservedNumber) {
+			return errors.New("extension field %q has an invalid number: %d", x.FullName(), x.Number())
+		}
+		if !x.Cardinality().IsValid() || x.Cardinality() == protoreflect.Required {
+			return errors.New("extension field %q has an invalid cardinality: %d", x.FullName(), x.Cardinality())
+		}
+		if xd.JsonName != nil {
+			// A bug in older versions of protoc would always populate the
+			// "json_name" option for extensions when it is meaningless.
+			// When it did so, it would always use the camel-cased field name.
+			if xd.GetJsonName() != strs.JSONCamelCase(string(x.Name())) {
+				return errors.New("extension field %q may not have an explicitly set JSON name: %q", x.FullName(), xd.GetJsonName())
+			}
+		}
+		if xd.OneofIndex != nil {
+			return errors.New("extension field %q may not be part of a oneof", x.FullName())
+		}
+		if md := x.ContainingMessage(); !md.IsPlaceholder() {
+			if !md.ExtensionRanges().Has(x.Number()) {
+				return errors.New("extension field %q extends %q with non-extension field number: %d", x.FullName(), md.FullName(), x.Number())
+			}
+			isMessageSet := md.Options().(*descriptorpb.MessageOptions).GetMessageSetWireFormat()
+			if isMessageSet && !isOptionalMessage(x) {
+				return errors.New("extension field %q extends MessageSet and must be an optional message", x.FullName())
+			}
+			if !isMessageSet && !x.Number().IsValid() {
+				return errors.New("extension field %q has an invalid number: %d", x.FullName(), x.Number())
+			}
+		}
+		if xd.GetOptions().GetWeak() {
+			return errors.New("extension field %q cannot be a weak reference", x.FullName())
+		}
+		if x.IsPacked() && !isPackable(x) {
+			return errors.New("extension field %q is not packable", x.FullName())
+		}
+		if err := checkValidGroup(x); err != nil {
+			return errors.New("extension field %q is an invalid group: %v", x.FullName(), err)
+		}
+		if md := x.Message(); md != nil && md.IsMapEntry() {
+			return errors.New("extension field %q cannot be a map entry", x.FullName())
+		}
+		if x.Syntax() == protoreflect.Proto3 {
+			switch x.ContainingMessage().FullName() {
+			case (*descriptorpb.FileOptions)(nil).ProtoReflect().Descriptor().FullName():
+			case (*descriptorpb.EnumOptions)(nil).ProtoReflect().Descriptor().FullName():
+			case (*descriptorpb.EnumValueOptions)(nil).ProtoReflect().Descriptor().FullName():
+			case (*descriptorpb.MessageOptions)(nil).ProtoReflect().Descriptor().FullName():
+			case (*descriptorpb.FieldOptions)(nil).ProtoReflect().Descriptor().FullName():
+			case (*descriptorpb.OneofOptions)(nil).ProtoReflect().Descriptor().FullName():
+			case (*descriptorpb.ExtensionRangeOptions)(nil).ProtoReflect().Descriptor().FullName():
+			case (*descriptorpb.ServiceOptions)(nil).ProtoReflect().Descriptor().FullName():
+			case (*descriptorpb.MethodOptions)(nil).ProtoReflect().Descriptor().FullName():
+			default:
+				return errors.New("extension field %q cannot be declared in proto3 unless extended descriptor options", x.FullName())
+			}
+		}
+	}
+	return nil
+}
+
+// isOptionalMessage reports whether this is an optional message.
+// If the kind is unknown, it is assumed to be a message.
+func isOptionalMessage(fd protoreflect.FieldDescriptor) bool {
+	return (fd.Kind() == 0 || fd.Kind() == protoreflect.MessageKind) && fd.Cardinality() == protoreflect.Optional
+}
+
+// isPackable checks whether the pack option can be specified.
+func isPackable(fd protoreflect.FieldDescriptor) bool {
+	switch fd.Kind() {
+	case protoreflect.StringKind, protoreflect.BytesKind, protoreflect.MessageKind, protoreflect.GroupKind:
+		return false
+	}
+	return fd.IsList()
+}
+
+// checkValidGroup reports whether fd is a valid group according to the same
+// rules that protoc imposes.
+func checkValidGroup(fd protoreflect.FieldDescriptor) error {
+	md := fd.Message()
+	switch {
+	case fd.Kind() != protoreflect.GroupKind:
+		return nil
+	case fd.Syntax() != protoreflect.Proto2:
+		return errors.New("invalid under proto2 semantics")
+	case md == nil || md.IsPlaceholder():
+		return errors.New("message must be resolvable")
+	case fd.FullName().Parent() != md.FullName().Parent():
+		return errors.New("message and field must be declared in the same scope")
+	case !unicode.IsUpper(rune(md.Name()[0])):
+		return errors.New("message name must start with an uppercase")
+	case fd.Name() != protoreflect.Name(strings.ToLower(string(md.Name()))):
+		return errors.New("field name must be lowercased form of the message name")
+	}
+	return nil
+}
+
+// checkValidMap checks whether the field is a valid map according to the same
+// rules that protoc imposes.
+// See protoc v3.8.0: src/google/protobuf/descriptor.cc:6045-6115
+func checkValidMap(fd protoreflect.FieldDescriptor) error {
+	md := fd.Message()
+	switch {
+	case md == nil || !md.IsMapEntry():
+		return nil
+	case fd.FullName().Parent() != md.FullName().Parent():
+		return errors.New("message and field must be declared in the same scope")
+	case md.Name() != protoreflect.Name(strs.MapEntryName(string(fd.Name()))):
+		return errors.New("incorrect implicit map entry name")
+	case fd.Cardinality() != protoreflect.Repeated:
+		return errors.New("field must be repeated")
+	case md.Fields().Len() != 2:
+		return errors.New("message must have exactly two fields")
+	case md.ExtensionRanges().Len() > 0:
+		return errors.New("message must not have any extension ranges")
+	case md.Enums().Len()+md.Messages().Len()+md.Extensions().Len() > 0:
+		return errors.New("message must not have any nested declarations")
+	}
+	kf := md.Fields().Get(0)
+	vf := md.Fields().Get(1)
+	switch {
+	case kf.Name() != genid.MapEntry_Key_field_name || kf.Number() != genid.MapEntry_Key_field_number || kf.Cardinality() != protoreflect.Optional || kf.ContainingOneof() != nil || kf.HasDefault():
+		return errors.New("invalid key field")
+	case vf.Name() != genid.MapEntry_Value_field_name || vf.Number() != genid.MapEntry_Value_field_number || vf.Cardinality() != protoreflect.Optional || vf.ContainingOneof() != nil || vf.HasDefault():
+		return errors.New("invalid value field")
+	}
+	switch kf.Kind() {
+	case protoreflect.BoolKind: // bool
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind: // int32
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind: // int64
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind: // uint32
+	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind: // uint64
+	case protoreflect.StringKind: // string
+	default:
+		return errors.New("invalid key kind: %v", kf.Kind())
+	}
+	if e := vf.Enum(); e != nil && e.Values().Len() > 0 && e.Values().Get(0).Number() != 0 {
+		return errors.New("map enum value must have zero number for the first value")
+	}
+	return nil
+}

--- a/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go
+++ b/vendor/google.golang.org/protobuf/reflect/protodesc/proto.go
@@ -1,0 +1,252 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package protodesc
+
+import (
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/internal/encoding/defval"
+	"google.golang.org/protobuf/internal/strs"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+// ToFileDescriptorProto copies a protoreflect.FileDescriptor into a
+// google.protobuf.FileDescriptorProto message.
+func ToFileDescriptorProto(file protoreflect.FileDescriptor) *descriptorpb.FileDescriptorProto {
+	p := &descriptorpb.FileDescriptorProto{
+		Name:    proto.String(file.Path()),
+		Options: proto.Clone(file.Options()).(*descriptorpb.FileOptions),
+	}
+	if file.Package() != "" {
+		p.Package = proto.String(string(file.Package()))
+	}
+	for i, imports := 0, file.Imports(); i < imports.Len(); i++ {
+		imp := imports.Get(i)
+		p.Dependency = append(p.Dependency, imp.Path())
+		if imp.IsPublic {
+			p.PublicDependency = append(p.PublicDependency, int32(i))
+		}
+		if imp.IsWeak {
+			p.WeakDependency = append(p.WeakDependency, int32(i))
+		}
+	}
+	for i, locs := 0, file.SourceLocations(); i < locs.Len(); i++ {
+		loc := locs.Get(i)
+		l := &descriptorpb.SourceCodeInfo_Location{}
+		l.Path = append(l.Path, loc.Path...)
+		if loc.StartLine == loc.EndLine {
+			l.Span = []int32{int32(loc.StartLine), int32(loc.StartColumn), int32(loc.EndColumn)}
+		} else {
+			l.Span = []int32{int32(loc.StartLine), int32(loc.StartColumn), int32(loc.EndLine), int32(loc.EndColumn)}
+		}
+		l.LeadingDetachedComments = append([]string(nil), loc.LeadingDetachedComments...)
+		if loc.LeadingComments != "" {
+			l.LeadingComments = proto.String(loc.LeadingComments)
+		}
+		if loc.TrailingComments != "" {
+			l.TrailingComments = proto.String(loc.TrailingComments)
+		}
+		if p.SourceCodeInfo == nil {
+			p.SourceCodeInfo = &descriptorpb.SourceCodeInfo{}
+		}
+		p.SourceCodeInfo.Location = append(p.SourceCodeInfo.Location, l)
+
+	}
+	for i, messages := 0, file.Messages(); i < messages.Len(); i++ {
+		p.MessageType = append(p.MessageType, ToDescriptorProto(messages.Get(i)))
+	}
+	for i, enums := 0, file.Enums(); i < enums.Len(); i++ {
+		p.EnumType = append(p.EnumType, ToEnumDescriptorProto(enums.Get(i)))
+	}
+	for i, services := 0, file.Services(); i < services.Len(); i++ {
+		p.Service = append(p.Service, ToServiceDescriptorProto(services.Get(i)))
+	}
+	for i, exts := 0, file.Extensions(); i < exts.Len(); i++ {
+		p.Extension = append(p.Extension, ToFieldDescriptorProto(exts.Get(i)))
+	}
+	if syntax := file.Syntax(); syntax != protoreflect.Proto2 {
+		p.Syntax = proto.String(file.Syntax().String())
+	}
+	return p
+}
+
+// ToDescriptorProto copies a protoreflect.MessageDescriptor into a
+// google.protobuf.DescriptorProto message.
+func ToDescriptorProto(message protoreflect.MessageDescriptor) *descriptorpb.DescriptorProto {
+	p := &descriptorpb.DescriptorProto{
+		Name:    proto.String(string(message.Name())),
+		Options: proto.Clone(message.Options()).(*descriptorpb.MessageOptions),
+	}
+	for i, fields := 0, message.Fields(); i < fields.Len(); i++ {
+		p.Field = append(p.Field, ToFieldDescriptorProto(fields.Get(i)))
+	}
+	for i, exts := 0, message.Extensions(); i < exts.Len(); i++ {
+		p.Extension = append(p.Extension, ToFieldDescriptorProto(exts.Get(i)))
+	}
+	for i, messages := 0, message.Messages(); i < messages.Len(); i++ {
+		p.NestedType = append(p.NestedType, ToDescriptorProto(messages.Get(i)))
+	}
+	for i, enums := 0, message.Enums(); i < enums.Len(); i++ {
+		p.EnumType = append(p.EnumType, ToEnumDescriptorProto(enums.Get(i)))
+	}
+	for i, xranges := 0, message.ExtensionRanges(); i < xranges.Len(); i++ {
+		xrange := xranges.Get(i)
+		p.ExtensionRange = append(p.ExtensionRange, &descriptorpb.DescriptorProto_ExtensionRange{
+			Start:   proto.Int32(int32(xrange[0])),
+			End:     proto.Int32(int32(xrange[1])),
+			Options: proto.Clone(message.ExtensionRangeOptions(i)).(*descriptorpb.ExtensionRangeOptions),
+		})
+	}
+	for i, oneofs := 0, message.Oneofs(); i < oneofs.Len(); i++ {
+		p.OneofDecl = append(p.OneofDecl, ToOneofDescriptorProto(oneofs.Get(i)))
+	}
+	for i, ranges := 0, message.ReservedRanges(); i < ranges.Len(); i++ {
+		rrange := ranges.Get(i)
+		p.ReservedRange = append(p.ReservedRange, &descriptorpb.DescriptorProto_ReservedRange{
+			Start: proto.Int32(int32(rrange[0])),
+			End:   proto.Int32(int32(rrange[1])),
+		})
+	}
+	for i, names := 0, message.ReservedNames(); i < names.Len(); i++ {
+		p.ReservedName = append(p.ReservedName, string(names.Get(i)))
+	}
+	return p
+}
+
+// ToFieldDescriptorProto copies a protoreflect.FieldDescriptor into a
+// google.protobuf.FieldDescriptorProto message.
+func ToFieldDescriptorProto(field protoreflect.FieldDescriptor) *descriptorpb.FieldDescriptorProto {
+	p := &descriptorpb.FieldDescriptorProto{
+		Name:    proto.String(string(field.Name())),
+		Number:  proto.Int32(int32(field.Number())),
+		Label:   descriptorpb.FieldDescriptorProto_Label(field.Cardinality()).Enum(),
+		Options: proto.Clone(field.Options()).(*descriptorpb.FieldOptions),
+	}
+	if field.IsExtension() {
+		p.Extendee = fullNameOf(field.ContainingMessage())
+	}
+	if field.Kind().IsValid() {
+		p.Type = descriptorpb.FieldDescriptorProto_Type(field.Kind()).Enum()
+	}
+	if field.Enum() != nil {
+		p.TypeName = fullNameOf(field.Enum())
+	}
+	if field.Message() != nil {
+		p.TypeName = fullNameOf(field.Message())
+	}
+	if field.HasJSONName() {
+		// A bug in older versions of protoc would always populate the
+		// "json_name" option for extensions when it is meaningless.
+		// When it did so, it would always use the camel-cased field name.
+		if field.IsExtension() {
+			p.JsonName = proto.String(strs.JSONCamelCase(string(field.Name())))
+		} else {
+			p.JsonName = proto.String(field.JSONName())
+		}
+	}
+	if field.Syntax() == protoreflect.Proto3 && field.HasOptionalKeyword() {
+		p.Proto3Optional = proto.Bool(true)
+	}
+	if field.HasDefault() {
+		def, err := defval.Marshal(field.Default(), field.DefaultEnumValue(), field.Kind(), defval.Descriptor)
+		if err != nil && field.DefaultEnumValue() != nil {
+			def = string(field.DefaultEnumValue().Name()) // occurs for unresolved enum values
+		} else if err != nil {
+			panic(fmt.Sprintf("%v: %v", field.FullName(), err))
+		}
+		p.DefaultValue = proto.String(def)
+	}
+	if oneof := field.ContainingOneof(); oneof != nil {
+		p.OneofIndex = proto.Int32(int32(oneof.Index()))
+	}
+	return p
+}
+
+// ToOneofDescriptorProto copies a protoreflect.OneofDescriptor into a
+// google.protobuf.OneofDescriptorProto message.
+func ToOneofDescriptorProto(oneof protoreflect.OneofDescriptor) *descriptorpb.OneofDescriptorProto {
+	return &descriptorpb.OneofDescriptorProto{
+		Name:    proto.String(string(oneof.Name())),
+		Options: proto.Clone(oneof.Options()).(*descriptorpb.OneofOptions),
+	}
+}
+
+// ToEnumDescriptorProto copies a protoreflect.EnumDescriptor into a
+// google.protobuf.EnumDescriptorProto message.
+func ToEnumDescriptorProto(enum protoreflect.EnumDescriptor) *descriptorpb.EnumDescriptorProto {
+	p := &descriptorpb.EnumDescriptorProto{
+		Name:    proto.String(string(enum.Name())),
+		Options: proto.Clone(enum.Options()).(*descriptorpb.EnumOptions),
+	}
+	for i, values := 0, enum.Values(); i < values.Len(); i++ {
+		p.Value = append(p.Value, ToEnumValueDescriptorProto(values.Get(i)))
+	}
+	for i, ranges := 0, enum.ReservedRanges(); i < ranges.Len(); i++ {
+		rrange := ranges.Get(i)
+		p.ReservedRange = append(p.ReservedRange, &descriptorpb.EnumDescriptorProto_EnumReservedRange{
+			Start: proto.Int32(int32(rrange[0])),
+			End:   proto.Int32(int32(rrange[1])),
+		})
+	}
+	for i, names := 0, enum.ReservedNames(); i < names.Len(); i++ {
+		p.ReservedName = append(p.ReservedName, string(names.Get(i)))
+	}
+	return p
+}
+
+// ToEnumValueDescriptorProto copies a protoreflect.EnumValueDescriptor into a
+// google.protobuf.EnumValueDescriptorProto message.
+func ToEnumValueDescriptorProto(value protoreflect.EnumValueDescriptor) *descriptorpb.EnumValueDescriptorProto {
+	return &descriptorpb.EnumValueDescriptorProto{
+		Name:    proto.String(string(value.Name())),
+		Number:  proto.Int32(int32(value.Number())),
+		Options: proto.Clone(value.Options()).(*descriptorpb.EnumValueOptions),
+	}
+}
+
+// ToServiceDescriptorProto copies a protoreflect.ServiceDescriptor into a
+// google.protobuf.ServiceDescriptorProto message.
+func ToServiceDescriptorProto(service protoreflect.ServiceDescriptor) *descriptorpb.ServiceDescriptorProto {
+	p := &descriptorpb.ServiceDescriptorProto{
+		Name:    proto.String(string(service.Name())),
+		Options: proto.Clone(service.Options()).(*descriptorpb.ServiceOptions),
+	}
+	for i, methods := 0, service.Methods(); i < methods.Len(); i++ {
+		p.Method = append(p.Method, ToMethodDescriptorProto(methods.Get(i)))
+	}
+	return p
+}
+
+// ToMethodDescriptorProto copies a protoreflect.MethodDescriptor into a
+// google.protobuf.MethodDescriptorProto message.
+func ToMethodDescriptorProto(method protoreflect.MethodDescriptor) *descriptorpb.MethodDescriptorProto {
+	p := &descriptorpb.MethodDescriptorProto{
+		Name:       proto.String(string(method.Name())),
+		InputType:  fullNameOf(method.Input()),
+		OutputType: fullNameOf(method.Output()),
+		Options:    proto.Clone(method.Options()).(*descriptorpb.MethodOptions),
+	}
+	if method.IsStreamingClient() {
+		p.ClientStreaming = proto.Bool(true)
+	}
+	if method.IsStreamingServer() {
+		p.ServerStreaming = proto.Bool(true)
+	}
+	return p
+}
+
+func fullNameOf(d protoreflect.Descriptor) *string {
+	if d == nil {
+		return nil
+	}
+	if strings.HasPrefix(string(d.FullName()), unknownPrefix) {
+		return proto.String(string(d.FullName()[len(unknownPrefix):]))
+	}
+	return proto.String("." + string(d.FullName()))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,5 @@
 # google.golang.org/protobuf v1.28.1
+google.golang.org/protobuf/compiler/protogen
 google.golang.org/protobuf/encoding/prototext
 google.golang.org/protobuf/encoding/protowire
 google.golang.org/protobuf/internal/descfmt
@@ -20,6 +21,7 @@ google.golang.org/protobuf/internal/set
 google.golang.org/protobuf/internal/strs
 google.golang.org/protobuf/internal/version
 google.golang.org/protobuf/proto
+google.golang.org/protobuf/reflect/protodesc
 google.golang.org/protobuf/reflect/protoreflect
 google.golang.org/protobuf/reflect/protoregistry
 google.golang.org/protobuf/runtime/protoiface


### PR DESCRIPTION
This PR adopts the [`protogen` support package](https://pkg.go.dev/google.golang.org/protobuf/compiler/protogen) for Protobuf plugins, obviating the need for custom parsing logic and facilitating [return of the `supported_features` in the `CodeGenerationResponse`](https://github.com/protocolbuffers/protobuf/blob/53e4fa327916bbb6b7e254ea5ee483407e2a509c/src/google/protobuf/compiler/plugin.proto#L95).

Tested locally by running against the existing `test.proto` and with the new `optional.proto`.

Closes #20